### PR TITLE
use openapi-spec-validator instead of swagger-validator

### DIFF
--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -11,7 +11,6 @@ test-db:
 test-prerequisite:
 	docker pull wazopbx/wait
 	docker pull wazopbx/postgres-test
-	docker pull swaggerapi/swagger-validator
 	docker pull rabbitmq
 	docker pull munkyboy/fakesmtp
 

--- a/integration_tests/assets/docker-compose.documentation.override.yml
+++ b/integration_tests/assets/docker-compose.documentation.override.yml
@@ -3,8 +3,7 @@ services:
   sync:
     depends_on:
       - auth
-      - swagger-validator
       - postgres
       - rabbitmq
     environment:
-      TARGETS: "auth:9497 swagger-validator:8080 postgres:5432 rabbitmq:5672"
+      TARGETS: "auth:9497 postgres:5432 rabbitmq:5672"

--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -53,8 +53,3 @@ services:
     image: munkyboy/fakesmtp
     ports:
       - "25"
-
-  swagger-validator:
-    image: swaggerapi/swagger-validator
-    ports:
-      - "8080"

--- a/integration_tests/suite/test_documentation.py
+++ b/integration_tests/suite/test_documentation.py
@@ -1,25 +1,24 @@
-# Copyright 2016-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import logging
 import requests
-import pprint
+import yaml
 
-from hamcrest import assert_that, empty
+from openapi_spec_validator import validate_v2_spec
 
 from .helpers.base import BaseTestCase
+
+logger = logging.getLogger('openapi_spec_validator')
+logger.setLevel(logging.INFO)
 
 
 class TestDocumentation(BaseTestCase):
 
     asset = 'documentation'
-    service = 'auth'
 
     def test_documentation_errors(self):
-        api_url = 'https://auth:9497/0.1/api/api.yml'
-        self.validate_api(api_url)
-
-    def validate_api(self, url):
-        port = self.service_port(8080, 'swagger-validator')
-        validator_url = 'http://localhost:{port}/debug'.format(port=port)
-        response = requests.get(validator_url, params={'url': url})
-        assert_that(response.json(), empty(), pprint.pformat(response.json()))
+        port = self.service_port(9497, 'auth')
+        api_url = 'https://localhost:{port}/0.1/api/api.yml'.format(port=port)
+        api = requests.get(api_url, verify=False)
+        validate_v2_spec(yaml.safe_load(api.text))

--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -1,10 +1,11 @@
 docker
 docker-compose
+kombu
 mock
 nose
+openapi-spec-validator
 pyhamcrest
 python-ldap
-kombu
 
 # for database tests
 -e ..


### PR DESCRIPTION
reason: openapi-spec-validator catches more errors