### PR TITLE
user_session: fix api tag

### DIFF
--- a/wazo_auth/plugins/http/user_session/api.yml
+++ b/wazo_auth/plugins/http/user_session/api.yml
@@ -35,7 +35,7 @@ paths:
     delete:
       operationId: user_delete_session
       tags:
-        - user
+        - users
         - sessions
       security:
       - wazo_auth_token: []


### PR DESCRIPTION
reason: other resources have "users" tag