### PR TITLE
Fix missing external auth api.yml files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     zip_safe=False,
     package_data={
         'wazo_auth.plugins.http': ['*/api.yml'],
+        'wazo_auth.plugins.external_auth': ['*/api.yml'],
     },
     scripts=[
         'bin/wazo-auth-init-db',


### PR DESCRIPTION
External_auth api.yml files were not included in package_data of setup.py