### PR TITLE
WAZO-4352: Force json decoding requests content

### DIFF
--- a/integration_tests/suite/test_http_interface.py
+++ b/integration_tests/suite/test_http_interface.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -143,45 +143,13 @@ class TestCore(base.APIIntegrationTest):
 
         assert_that(response.status_code, equal_to(400))
 
-    def _make_http_request(
-        self, verb: str, endpoint: str, body: str | None, headers: dict = None
-    ):
-        base_url = f'http://127.0.0.1:{self.auth_port()}/0.1/'
-        default_headers = {
-            'X-Auth-Token': self.admin_token,
-        }
-        req_headers = default_headers if not headers else headers
-
-        match verb.lower():
-            case 'patch':
-                call = requests.patch
-            case 'post':
-                call = requests.post  # type: ignore
-            case 'put':
-                call = requests.put  # type: ignore
-            case _:
-                raise ValueError('An unexpected http verb was given')
-
-        return call(
-            base_url + endpoint,
-            headers=req_headers,
-            data=body,
-            verify=False,
-        )
-
     @fixtures.http.group()
     def test_empty_body_for_group_requests(self, test_group):
         urls = [
             ('POST', 'groups'),
             ('PUT', f'groups/{test_group["uuid"]}'),
         ]
-
-        for method, url in urls:
-            response = self._make_http_request(method, url, '')
-            assert response.status_code == 400, f'Error with url: ({method}) {url}'
-
-            response = self._make_http_request(method, url, None)
-            assert response.status_code == 400, f'Error with url: ({method}) {url}'
+        self.assert_empty_body_returns_400(urls)
 
     @fixtures.http.tenant()
     def test_empty_body_for_tenant_requests(self, test_tenant):
@@ -189,13 +157,7 @@ class TestCore(base.APIIntegrationTest):
             ('POST', 'tenants'),
             ('PUT', f'tenants/{test_tenant["uuid"]}'),
         ]
-
-        for method, url in urls:
-            response = self._make_http_request(method, url, '')
-            assert response.status_code == 400, f'Error with url: ({method}) {url}'
-
-            response = self._make_http_request(method, url, None)
-            assert response.status_code == 400, f'Error with url: ({method}) {url}'
+        self.assert_empty_body_returns_400(urls)
 
     @fixtures.http.user()
     def test_empty_body_for_user_requests(self, test_user):
@@ -210,13 +172,7 @@ class TestCore(base.APIIntegrationTest):
             ('POST', f'users/{test_user["uuid"]}/external/microsoft'),
             ('POST', f'users/{test_user["uuid"]}/external/google'),
         ]
-
-        for method, url in urls:
-            response = self._make_http_request(method, url, '')
-            assert response.status_code == 400, f'Error with url: ({method}) {url}'
-
-            response = self._make_http_request(method, url, None)
-            assert response.status_code == 400, f'Error with url: ({method}) {url}'
+        self.assert_empty_body_returns_400(urls)
 
     @fixtures.http.user(username='username', password='pass')
     @fixtures.http.token(username='username', password='pass')
@@ -225,13 +181,7 @@ class TestCore(base.APIIntegrationTest):
             ('POST', 'token'),
             ('POST', f'token/{test_token["token"]}/scopes/check'),
         ]
-
-        for method, url in urls:
-            response = self._make_http_request(method, url, '')
-            assert response.status_code == 400, f'Error with url: ({method}) {url}'
-
-            response = self._make_http_request(method, url, None)
-            assert response.status_code == 400, f'Error with url: ({method}) {url}'
+        self.assert_empty_body_returns_400(urls)
 
     @fixtures.http.policy()
     def test_empty_body_for_policy_requests(self, test_policy):
@@ -239,13 +189,7 @@ class TestCore(base.APIIntegrationTest):
             ('POST', 'policies'),
             ('PUT', f'policies/{test_policy["uuid"]}'),
         ]
-
-        for method, url in urls:
-            response = self._make_http_request(method, url, '')
-            assert response.status_code == 400, f'Error with url: ({method}) {url}'
-
-            response = self._make_http_request(method, url, None)
-            assert response.status_code == 400, f'Error with url: ({method}) {url}'
+        self.assert_empty_body_returns_400(urls)
 
     def test_that_empty_body_for_request_returns_400(self):
         urls = [
@@ -256,13 +200,7 @@ class TestCore(base.APIIntegrationTest):
             ('PUT', 'idp/saml/users'),
             ('PUT', 'backends/ldap'),
         ]
-
-        for method, url in urls:
-            response = self._make_http_request(method, url, '')
-            assert response.status_code == 400, f'Error with url: ({method}) {url}'
-
-            response = self._make_http_request(method, url, None)
-            assert response.status_code == 400, f'Error with url: ({method}) {url}'
+        self.assert_empty_body_returns_400(urls)
 
     def test_the_expiration_argument(self):
         token_data = self._post_token('foo', 'bar', expiration=2)

--- a/integration_tests/suite/test_http_interface.py
+++ b/integration_tests/suite/test_http_interface.py
@@ -144,8 +144,9 @@ class TestCore(base.APIIntegrationTest):
         assert_that(response.status_code, equal_to(400))
 
     def _make_http_request(
-        self, verb: str, url: str, body: str | None, headers: dict = None
+        self, verb: str, endpoint: str, body: str | None, headers: dict = None
     ):
+        base_url = f'http://127.0.0.1:{self.auth_port()}/0.1/'
         default_headers = {
             'X-Auth-Token': self.admin_token,
         }
@@ -162,7 +163,7 @@ class TestCore(base.APIIntegrationTest):
                 raise ValueError('An unexpected http verb was given')
 
         return call(
-            url,
+            base_url + endpoint,
             headers=req_headers,
             data=body,
             verify=False,
@@ -170,104 +171,98 @@ class TestCore(base.APIIntegrationTest):
 
     @fixtures.http.group()
     def test_empty_body_for_group_requests(self, test_group):
-        base_url = f'http://127.0.0.1:{self.auth_port()}'
         urls = [
-            ('POST', f'{base_url}/0.1/groups'),
-            ('PUT', f'{base_url}/0.1/groups/{test_group["uuid"]}'),
+            ('POST', 'groups'),
+            ('PUT', f'groups/{test_group["uuid"]}'),
         ]
 
-        for url in urls:
-            response = self._make_http_request(url[0], url[1], '')
-            assert response.status_code == 400, f'Error with url: {url}'
+        for method, url in urls:
+            response = self._make_http_request(method, url, '')
+            assert response.status_code == 400, f'Error with url: ({method}) {url}'
 
-            response = self._make_http_request(url[0], url[1], None)
-            assert response.status_code == 400, f'Error with url: {url}'
+            response = self._make_http_request(method, url, None)
+            assert response.status_code == 400, f'Error with url: ({method}) {url}'
 
     @fixtures.http.tenant()
     def test_empty_body_for_tenant_requests(self, test_tenant):
-        base_url = f'http://127.0.0.1:{self.auth_port()}'
         urls = [
-            ('POST', f'{base_url}/0.1/tenants'),
-            ('PUT', f'{base_url}/0.1/tenants/{test_tenant["uuid"]}'),
+            ('POST', 'tenants'),
+            ('PUT', f'tenants/{test_tenant["uuid"]}'),
         ]
 
-        for url in urls:
-            response = self._make_http_request(url[0], url[1], '')
-            assert response.status_code == 400, f'Error with url: {url}'
+        for method, url in urls:
+            response = self._make_http_request(method, url, '')
+            assert response.status_code == 400, f'Error with url: ({method}) {url}'
 
-            response = self._make_http_request(url[0], url[1], None)
-            assert response.status_code == 400, f'Error with url: {url}'
+            response = self._make_http_request(method, url, None)
+            assert response.status_code == 400, f'Error with url: ({method}) {url}'
 
     @fixtures.http.user()
     def test_empty_body_for_user_requests(self, test_user):
-        base_url = f'http://127.0.0.1:{self.auth_port()}'
         urls = [
-            ('POST', f'{base_url}/0.1/users'),
-            ('PUT', f'{base_url}/0.1/users/{test_user["uuid"]}'),
-            ('PUT', f'{base_url}/0.1/users/{test_user["uuid"]}/password'),
-            ('PUT', f'{base_url}/0.1/users/{test_user["uuid"]}/emails'),
-            ('POST', f'{base_url}/0.1/users/register'),
-            ('POST', f'{base_url}/0.1/users/{test_user["uuid"]}/external/mobile'),
-            ('PUT', f'{base_url}/0.1/users/{test_user["uuid"]}/external/mobile'),
-            ('POST', f'{base_url}/0.1/users/{test_user["uuid"]}/external/microsoft'),
-            ('POST', f'{base_url}/0.1/users/{test_user["uuid"]}/external/google'),
+            ('POST', 'users'),
+            ('POST', 'users/register'),
+            ('PUT', f'users/{test_user["uuid"]}'),
+            ('PUT', f'users/{test_user["uuid"]}/password'),
+            ('PUT', f'users/{test_user["uuid"]}/emails'),
+            ('POST', f'users/{test_user["uuid"]}/external/mobile'),
+            ('PUT', f'users/{test_user["uuid"]}/external/mobile'),
+            ('POST', f'users/{test_user["uuid"]}/external/microsoft'),
+            ('POST', f'users/{test_user["uuid"]}/external/google'),
         ]
 
-        for url in urls:
-            response = self._make_http_request(url[0], url[1], '')
-            assert response.status_code == 400, f'Error with url: {url}'
+        for method, url in urls:
+            response = self._make_http_request(method, url, '')
+            assert response.status_code == 400, f'Error with url: ({method}) {url}'
 
-            response = self._make_http_request(url[0], url[1], None)
-            assert response.status_code == 400, f'Error with url: {url}'
+            response = self._make_http_request(method, url, None)
+            assert response.status_code == 400, f'Error with url: ({method}) {url}'
 
     @fixtures.http.user(username='username', password='pass')
     @fixtures.http.token(username='username', password='pass')
     def test_empty_body_for_token_requests(self, _, test_token):
-        base_url = f'http://127.0.0.1:{self.auth_port()}'
         urls = [
-            ('POST', f'{base_url}/0.1/token/{test_token["token"]}/scopes/check'),
-            ('POST', f'{base_url}/0.1/token'),
+            ('POST', 'token'),
+            ('POST', f'token/{test_token["token"]}/scopes/check'),
         ]
 
-        for url in urls:
-            response = self._make_http_request(url[0], url[1], '')
-            assert response.status_code == 400, f'Error with url: {url}'
+        for method, url in urls:
+            response = self._make_http_request(method, url, '')
+            assert response.status_code == 400, f'Error with url: ({method}) {url}'
 
-            response = self._make_http_request(url[0], url[1], None)
-            assert response.status_code == 400, f'Error with url: {url}'
+            response = self._make_http_request(method, url, None)
+            assert response.status_code == 400, f'Error with url: ({method}) {url}'
 
     @fixtures.http.policy()
     def test_empty_body_for_policy_requests(self, test_policy):
-        base_url = f'http://127.0.0.1:{self.auth_port()}'
         urls = [
-            ('POST', f'{base_url}/0.1/policies'),
-            ('PUT', f'{base_url}/0.1/policies/{test_policy["uuid"]}'),
+            ('POST', 'policies'),
+            ('PUT', f'policies/{test_policy["uuid"]}'),
         ]
 
-        for url in urls:
-            response = self._make_http_request(url[0], url[1], '')
-            assert response.status_code == 400, f'Error with url: {url}'
+        for method, url in urls:
+            response = self._make_http_request(method, url, '')
+            assert response.status_code == 400, f'Error with url: ({method}) {url}'
 
-            response = self._make_http_request(url[0], url[1], None)
-            assert response.status_code == 400, f'Error with url: {url}'
+            response = self._make_http_request(method, url, None)
+            assert response.status_code == 400, f'Error with url: ({method}) {url}'
 
     def test_that_empty_body_for_request_returns_400(self):
-        base_url = f'http://127.0.0.1:{self.auth_port()}'
         urls = [
-            ('PATCH', f'{base_url}/0.1/config'),
-            ('POST', f'{base_url}/0.1/external/google/config'),
-            ('PUT', f'{base_url}/0.1/external/google/config'),
-            ('POST', f'{base_url}/0.1/saml/sso'),
-            ('PUT', f'{base_url}/0.1/idp/saml/users'),
-            ('PUT', f'{base_url}/0.1/backends/ldap'),
+            ('PATCH', 'config'),
+            ('POST', 'external/google/config'),
+            ('PUT', 'external/google/config'),
+            ('POST', 'saml/sso'),
+            ('PUT', 'idp/saml/users'),
+            ('PUT', 'backends/ldap'),
         ]
 
-        for url in urls:
-            response = self._make_http_request(url[0], url[1], '')
-            assert response.status_code == 400, f'Error with url: {url}'
+        for method, url in urls:
+            response = self._make_http_request(method, url, '')
+            assert response.status_code == 400, f'Error with url: ({method}) {url}'
 
-            response = self._make_http_request(url[0], url[1], None)
-            assert response.status_code == 400, f'Error with url: {url}'
+            response = self._make_http_request(method, url, None)
+            assert response.status_code == 400, f'Error with url: ({method}) {url}'
 
     def test_the_expiration_argument(self):
         token_data = self._post_token('foo', 'bar', expiration=2)

--- a/integration_tests/suite/test_http_interface.py
+++ b/integration_tests/suite/test_http_interface.py
@@ -207,16 +207,23 @@ class TestCore(base.APIIntegrationTest):
         ]
         self.assert_empty_body_returns_400(urls)
 
-    def test_that_empty_body_for_request_returns_400(self):
-        urls = [
-            ('PATCH', 'config'),
-            ('POST', 'external/google/config'),
-            ('PUT', 'external/google/config'),
-            ('POST', 'saml/sso'),
-            ('PUT', 'idp/saml/users'),
-            ('PUT', 'backends/ldap'),
-        ]
-        self.assert_empty_body_returns_400(urls)
+    def test_that_empty_body_when_patch_config_returns_400(self):
+        self.assert_empty_body_returns_400([('PATCH', 'config')])
+
+    def test_that_empty_body_when_post_google_config_returns_400(self):
+        self.assert_empty_body_returns_400([('POST', 'external/google/config')])
+
+    def test_that_empty_body_when_put_google_config_returns_400(self):
+        self.assert_empty_body_returns_400([('PUT', 'external/google/config')])
+
+    def test_that_empty_body_when_post_saml_sso_returns_400(self):
+        self.assert_empty_body_returns_400([('POST', 'saml/sso')])
+
+    def test_that_empty_body_when_put_saml_user_returns_400(self):
+        self.assert_empty_body_returns_400([('PUT', 'idp/saml/users')])
+
+    def test_that_empty_body_when_put_ldap_request_returns_400(self):
+        self.assert_empty_body_returns_400([('PUT', 'backends/ldap')])
 
     def test_the_expiration_argument(self):
         token_data = self._post_token('foo', 'bar', expiration=2)

--- a/integration_tests/suite/test_http_interface.py
+++ b/integration_tests/suite/test_http_interface.py
@@ -158,6 +158,8 @@ class TestCore(base.APIIntegrationTest):
                 call = requests.post  # type: ignore
             case 'put':
                 call = requests.put  # type: ignore
+            case _:
+                raise ValueError('An unexpected http verb was given')
 
         return call(
             url,

--- a/integration_tests/suite/test_http_interface.py
+++ b/integration_tests/suite/test_http_interface.py
@@ -225,6 +225,9 @@ class TestCore(base.APIIntegrationTest):
     def test_that_empty_body_when_put_ldap_request_returns_400(self):
         self.assert_empty_body_returns_400([('PUT', 'backends/ldap')])
 
+    def test_that_empty_body_when_post_password_reset_request_returns_400(self):
+        self.assert_empty_body_returns_400([('POST', 'users/password/reset')])
+
     def test_the_expiration_argument(self):
         token_data = self._post_token('foo', 'bar', expiration=2)
 

--- a/integration_tests/suite/test_http_interface.py
+++ b/integration_tests/suite/test_http_interface.py
@@ -143,6 +143,19 @@ class TestCore(base.APIIntegrationTest):
 
         assert_that(response.status_code, equal_to(400))
 
+    def test_that_empty_body_returns_400(self):
+        url = f'http://127.0.0.1:{self.auth_port()}/0.1/users'
+        headers = {
+            'Accept': 'application/json',
+            'X-Auth-Token': self.admin_token,
+        }
+
+        response = requests.post(url, headers=headers, data='', verify=False)
+        assert_that(response.status_code, equal_to(400))
+
+        response = requests.post(url, headers=headers, data=None, verify=False)
+        assert_that(response.status_code, equal_to(400))
+
     def test_the_expiration_argument(self):
         token_data = self._post_token('foo', 'bar', expiration=2)
 

--- a/integration_tests/suite/test_http_interface.py
+++ b/integration_tests/suite/test_http_interface.py
@@ -152,25 +152,36 @@ class TestCore(base.APIIntegrationTest):
         self.assert_empty_body_returns_400(urls)
 
     @fixtures.http.tenant()
-    def test_empty_body_for_tenant_requests_returns_400(self, test_tenant):
+    def test_empty_body_for_update_tenant_requests_returns_400(self, test_tenant):
         urls = [
-            ('POST', 'tenants'),
             ('PUT', f'tenants/{test_tenant["uuid"]}'),
         ]
         self.assert_empty_body_returns_400(urls)
 
+    def test_empty_body_for_create_tenant_requests_returns_400(self):
+        urls = [
+            ('POST', 'tenants'),
+        ]
+        self.assert_empty_body_returns_400(urls)
+
     @fixtures.http.user()
-    def test_empty_body_for_user_requests_returns_400(self, test_user):
+    def test_empty_body_for_create_user_requests_returns_400(self, test_user):
         urls = [
             ('POST', 'users'),
             ('POST', 'users/register'),
+            ('POST', f'users/{test_user["uuid"]}/external/mobile'),
+            ('POST', f'users/{test_user["uuid"]}/external/microsoft'),
+            ('POST', f'users/{test_user["uuid"]}/external/google'),
+        ]
+        self.assert_empty_body_returns_400(urls)
+
+    @fixtures.http.user()
+    def test_empty_body_for_update_user_requests_returns_400(self, test_user):
+        urls = [
             ('PUT', f'users/{test_user["uuid"]}'),
             ('PUT', f'users/{test_user["uuid"]}/password'),
             ('PUT', f'users/{test_user["uuid"]}/emails'),
-            ('POST', f'users/{test_user["uuid"]}/external/mobile'),
             ('PUT', f'users/{test_user["uuid"]}/external/mobile'),
-            ('POST', f'users/{test_user["uuid"]}/external/microsoft'),
-            ('POST', f'users/{test_user["uuid"]}/external/google'),
         ]
         self.assert_empty_body_returns_400(urls)
 
@@ -183,10 +194,15 @@ class TestCore(base.APIIntegrationTest):
         ]
         self.assert_empty_body_returns_400(urls)
 
-    @fixtures.http.policy()
-    def test_empty_body_for_policy_requests_returns_400(self, test_policy):
+    def test_empty_body_for_create_policy_requests_returns_400(self):
         urls = [
             ('POST', 'policies'),
+        ]
+        self.assert_empty_body_returns_400(urls)
+
+    @fixtures.http.policy()
+    def test_empty_body_for_update_policy_requests_returns_400(self, test_policy):
+        urls = [
             ('PUT', f'policies/{test_policy["uuid"]}'),
         ]
         self.assert_empty_body_returns_400(urls)

--- a/integration_tests/suite/test_http_interface.py
+++ b/integration_tests/suite/test_http_interface.py
@@ -144,7 +144,7 @@ class TestCore(base.APIIntegrationTest):
         assert_that(response.status_code, equal_to(400))
 
     @fixtures.http.group()
-    def test_empty_body_for_group_requests(self, test_group):
+    def test_empty_body_for_group_requests_returns_400(self, test_group):
         urls = [
             ('POST', 'groups'),
             ('PUT', f'groups/{test_group["uuid"]}'),
@@ -152,7 +152,7 @@ class TestCore(base.APIIntegrationTest):
         self.assert_empty_body_returns_400(urls)
 
     @fixtures.http.tenant()
-    def test_empty_body_for_tenant_requests(self, test_tenant):
+    def test_empty_body_for_tenant_requests_returns_400(self, test_tenant):
         urls = [
             ('POST', 'tenants'),
             ('PUT', f'tenants/{test_tenant["uuid"]}'),
@@ -160,7 +160,7 @@ class TestCore(base.APIIntegrationTest):
         self.assert_empty_body_returns_400(urls)
 
     @fixtures.http.user()
-    def test_empty_body_for_user_requests(self, test_user):
+    def test_empty_body_for_user_requests_returns_400(self, test_user):
         urls = [
             ('POST', 'users'),
             ('POST', 'users/register'),
@@ -176,7 +176,7 @@ class TestCore(base.APIIntegrationTest):
 
     @fixtures.http.user(username='username', password='pass')
     @fixtures.http.token(username='username', password='pass')
-    def test_empty_body_for_token_requests(self, _, test_token):
+    def test_empty_body_for_token_requests_returns_400(self, _, test_token):
         urls = [
             ('POST', 'token'),
             ('POST', f'token/{test_token["token"]}/scopes/check'),
@@ -184,7 +184,7 @@ class TestCore(base.APIIntegrationTest):
         self.assert_empty_body_returns_400(urls)
 
     @fixtures.http.policy()
-    def test_empty_body_for_policy_requests(self, test_policy):
+    def test_empty_body_for_policy_requests_returns_400(self, test_policy):
         urls = [
             ('POST', 'policies'),
             ('PUT', f'policies/{test_policy["uuid"]}'),

--- a/wazo_auth/plugins/external_auth/google/http.py
+++ b/wazo_auth/plugins/external_auth/google/http.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -43,7 +43,7 @@ class GoogleAuth(http.AuthResource):
     @http.required_acl('auth.users.{user_uuid}.external.google.create')
     def post(self, user_uuid):
         try:
-            args = GoogleSchema().load(request.get_json())
+            args = GoogleSchema().load(request.get_json(force=True))
         except ValidationError as e:
             raise UserParamException.from_errors(e.messages)
 

--- a/wazo_auth/plugins/external_auth/microsoft/http.py
+++ b/wazo_auth/plugins/external_auth/microsoft/http.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -42,7 +42,7 @@ class MicrosoftAuth(http.AuthResource):
     @http.required_acl('auth.users.{user_uuid}.external.microsoft.create')
     def post(self, user_uuid):
         try:
-            args = MicrosoftSchema().load(request.get_json())
+            args = MicrosoftSchema().load(request.get_json(force=True))
         except marshmallow.ValidationError as e:
             raise UserParamException.from_errors(e.messages)
 

--- a/wazo_auth/plugins/external_auth/mobile/http.py
+++ b/wazo_auth/plugins/external_auth/mobile/http.py
@@ -51,7 +51,7 @@ class MobileAuth(http.AuthResource):
     @http.required_acl('auth.users.{user_uuid}.external.mobile.create')
     def post(self, user_uuid):
         try:
-            args = MobileSchema().load(request.get_json())
+            args = MobileSchema().load(request.get_json(force=True))
         except marshmallow.ValidationError as e:
             raise exceptions.UserParamException.from_errors(e.messages)
 
@@ -64,7 +64,7 @@ class MobileAuth(http.AuthResource):
     @http.required_acl('auth.users.{user_uuid}.external.mobile.update')
     def put(self, user_uuid):
         try:
-            args = MobileSchema().load(request.get_json())
+            args = MobileSchema().load(request.get_json(force=True))
         except marshmallow.ValidationError as e:
             raise exceptions.UserParamException.from_errors(e.messages)
 

--- a/wazo_auth/plugins/http/config/http.py
+++ b/wazo_auth/plugins/http/config/http.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from flask import request
@@ -22,7 +22,7 @@ class ConfigResource(AuthResource):
     @required_acl('auth.config.update')
     @required_top_tenant()
     def patch(self):
-        config_patch = config_patch_schema.load(request.get_json(), many=True)
+        config_patch = config_patch_schema.load(request.get_json(force=True), many=True)
         config = self._config_service.get_config()
         patched_config = JsonPatch(config_patch).apply(config)
         self._config_service.update_config(patched_config)

--- a/wazo_auth/plugins/http/external/http.py
+++ b/wazo_auth/plugins/http/external/http.py
@@ -50,14 +50,14 @@ class ExternalConfig(http.AuthResource):
 
     @http.required_acl('auth.{auth_type}.external.config.create')
     def post(self, auth_type):
-        data = request.get_json()
+        data = request.get_json(force=True)
         tenant_uuid = Tenant.autodetect().uuid
         self.external_auth_service.create_config(auth_type, data, tenant_uuid)
         return '', 201
 
     @http.required_acl('auth.{auth_type}.external.config.update')
     def put(self, auth_type):
-        data = request.get_json()
+        data = request.get_json(force=True)
         tenant_uuid = Tenant.autodetect().uuid
         self.external_auth_service.update_config(auth_type, data, tenant_uuid)
         return '', 204

--- a/wazo_auth/plugins/http/groups/http.py
+++ b/wazo_auth/plugins/http/groups/http.py
@@ -30,7 +30,7 @@ class Group(_BaseGroupResource):
         tenant_uuids = get_tenant_uuids(recurse=True)
         self.group_service.assert_group_in_subtenant(tenant_uuids, group_uuid)
         try:
-            body = schemas.GroupPutSchema().load(request.get_json())
+            body = schemas.GroupPutSchema().load(request.get_json(force=True))
         except marshmallow.ValidationError as e:
             raise exceptions.GroupParamException.from_errors(e.messages)
 
@@ -66,7 +66,7 @@ class Groups(_BaseGroupResource):
     @http.required_acl('auth.groups.create')
     def post(self):
         try:
-            args = schemas.GroupRequestSchema().load(request.get_json())
+            args = schemas.GroupRequestSchema().load(request.get_json(force=True))
         except marshmallow.ValidationError as e:
             raise exceptions.GroupParamException.from_errors(e.messages)
 

--- a/wazo_auth/plugins/http/idp/http.py
+++ b/wazo_auth/plugins/http/idp/http.py
@@ -63,7 +63,7 @@ class IDPUsers(_BaseIDPUser):
         scoping_tenant = Tenant.autodetect()
 
         try:
-            form = IDPUsersSchema().load(request.get_json())
+            form = IDPUsersSchema().load(request.get_json(force=True))
         except marshmallow.ValidationError as e:
             raise exceptions.InvalidListParamException(e.messages)
 

--- a/wazo_auth/plugins/http/password_reset/http.py
+++ b/wazo_auth/plugins/http/password_reset/http.py
@@ -74,7 +74,7 @@ class PasswordReset(http.ErrorCatchingResource):
             raise Unauthorized(token_id)
 
         try:
-            args = PasswordResetPostParameters().load(request.get_json())
+            args = PasswordResetPostParameters().load(request.get_json(force=True))
         except marshmallow.ValidationError as e:
             raise PasswordResetException.from_errors(e.messages)
 

--- a/wazo_auth/plugins/http/saml/http.py
+++ b/wazo_auth/plugins/http/saml/http.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2024-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
@@ -55,7 +55,7 @@ class SAMLSSO(http.ErrorCatchingResource):
 
     def post(self):
         try:
-            args = self._schema.load(request.get_json())
+            args = self._schema.load(request.get_json(force=True))
         except marshmallow.ValidationError as e:
             for field in e.messages:
                 logger.info(

--- a/wazo_auth/plugins/http/tenants/http.py
+++ b/wazo_auth/plugins/http/tenants/http.py
@@ -48,7 +48,7 @@ class Tenant(BaseResource):
     def put(self, tenant_uuid):
         scoping_tenant = TenantDetector.autodetect()
         try:
-            args = tenant_put_schema.load(request.get_json())
+            args = tenant_put_schema.load(request.get_json(force=True))
         except ValidationError as e:
             raise exceptions.TenantParamException.from_errors(e.messages)
 
@@ -97,7 +97,7 @@ class Tenants(BaseResource):
             request.get_json(force=True),
         )
         try:
-            args = tenant_post_schema.load(request.get_json())
+            args = tenant_post_schema.load(request.get_json(force=True))
         except ValidationError as e:
             raise exceptions.TenantParamException.from_errors(e.messages)
 

--- a/wazo_auth/plugins/http/user_email/http.py
+++ b/wazo_auth/plugins/http/user_email/http.py
@@ -21,7 +21,7 @@ class _EmailUpdate(http.AuthResource):
 
     def put(self, user_uuid):
         try:
-            args = self.EmailPutSchema().load(request.get_json())
+            args = self.EmailPutSchema().load(request.get_json(force=True))
         except marshmallow.ValidationError as e:
             raise exceptions.EmailUpdateException(e.messages)
 

--- a/wazo_auth/plugins/http/user_registration/http.py
+++ b/wazo_auth/plugins/http/user_registration/http.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import marshmallow
@@ -19,7 +19,7 @@ class Register(http.ErrorCatchingResource):
 
     def post(self):
         try:
-            args = UserRegisterPostSchema().load(request.get_json())
+            args = UserRegisterPostSchema().load(request.get_json(force=True))
         except marshmallow.ValidationError as e:
             raise exceptions.UserParamException.from_errors(e.messages)
 

--- a/wazo_auth/plugins/http/users/http.py
+++ b/wazo_auth/plugins/http/users/http.py
@@ -43,7 +43,7 @@ class User(BaseUserService):
     def put(self, user_uuid):
         scoping_tenant = Tenant.autodetect()
         try:
-            args = user_put_schema.load(request.get_json())
+            args = user_put_schema.load(request.get_json(force=True))
         except marshmallow.ValidationError as e:
             raise exceptions.UserParamException.from_errors(e.messages)
 
@@ -61,7 +61,7 @@ class UserPassword(BaseUserService):
     @http.required_acl('auth.users.{user_uuid}.password.update')
     def put(self, user_uuid):
         try:
-            args = change_password_schema.load(request.get_json())
+            args = change_password_schema.load(request.get_json(force=True))
         except marshmallow.ValidationError as e:
             raise exceptions.PasswordChangeException.from_errors(e.messages)
         self.user_service.change_password(user_uuid, **args)
@@ -95,7 +95,7 @@ class Users(BaseUserService):
     def post(self):
         tenant = Tenant.autodetect()
         try:
-            args = user_post_schema.load(request.get_json())
+            args = user_post_schema.load(request.get_json(force=True))
         except marshmallow.ValidationError as e:
             raise exceptions.UserParamException.from_errors(e.messages)
 


### PR DESCRIPTION
Why: forces to decode request content as json even if the content type isn't defined

WAZO-4352

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes JSON body handling by forcing JSON parsing even when Content-Type is missing and validates that empty bodies are rejected.
> 
> - Replace `request.get_json()` with `request.get_json(force=True)` across endpoints: external auth (`google`, `microsoft`, `mobile`), config patch, external config (`post`/`put`), groups (`post`/`put`), IDP users (`put`), password reset (`post`), SAML SSO (`post`), tenants (`post`/`put`), user email update (`put`), user registration (`post`), users (`post`/`put`/password `put`)
> - Integration tests: add `_make_http_request` helper and `assert_empty_body_returns_400`; new tests verify `400` on empty bodies for groups, tenants, users (create/update/external), tokens, policies, config, SAML SSO, IDP SAML users, LDAP backend, Google external config, and password reset
> - Minor: update copyright years
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0bb8218c56fd1d3c1387510f470c4ad694bcf94a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->