### PR TITLE
NES-2728-auth-parent-uuid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 26.03
+
+* Added API `PUT /0.1/tenants/<tenant_uuid>/parent/<new_parent_uuid>`
+
 ## 25.14
 
 * `PUT /0.1/users/<user_uuid>/external/mobile`: now creates the resource if it does not already exist

--- a/integration_tests/suite/test_tenants.py
+++ b/integration_tests/suite/test_tenants.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from uuid import uuid4
@@ -13,6 +13,7 @@ from hamcrest import (
     has_entry,
     has_item,
     is_,
+    not_,
 )
 from wazo_test_helpers import until
 from wazo_test_helpers.hamcrest.uuid_ import uuid_
@@ -571,3 +572,41 @@ class TestTenants(base.APIIntegrationTest):
         assert_that(result['items'], empty())
 
         assert_http_error(404, self.client.tenants.get_domains, UNKNOWN_UUID)
+
+    @fixtures.http.tenant()
+    def test_put_parent_errors(self, tenant):
+        args = {'parent_uuid': tenant['uuid']}
+        with self.client_in_subtenant(**args) as (client, _, sub_tenant):
+            # From sub-tenant, tenant is not found
+            new_parent_uuid = sub_tenant['uuid']
+            assert_http_error(
+                404,
+                client.tenants.update_parent,
+                tenant['uuid'],
+                new_parent_uuid,
+            )
+            # From sub-tenant, new parent is not found
+            new_parent_uuid = tenant['uuid']
+            assert_http_error(
+                404,
+                client.tenants.update_parent,
+                sub_tenant['uuid'],
+                new_parent_uuid,
+            )
+
+    @fixtures.http.tenant()
+    def test_put_parent(self, tenant):
+        with self.client_in_subtenant() as (client, _, sub_tenant):
+            new_parent_uuid = tenant['uuid']
+
+            result = self.client.tenants.get(sub_tenant['uuid'])
+            assert_that(result['parent_uuid'], not_(equal_to(new_parent_uuid)))
+
+            assert_no_error(
+                self.client.tenants.update_parent,  # From master tenant
+                sub_tenant['uuid'],
+                new_parent_uuid,
+            )
+
+            result = self.client.tenants.get(sub_tenant['uuid'])
+            assert_that(result['parent_uuid'], equal_to(new_parent_uuid))

--- a/integration_tests/suite/test_tenants.py
+++ b/integration_tests/suite/test_tenants.py
@@ -594,6 +594,15 @@ class TestTenants(base.APIIntegrationTest):
                 new_parent_uuid,
             )
 
+            # From master, loop detection
+            new_parent_uuid = sub_tenant['uuid']
+            assert_http_error(
+                409,
+                self.client.tenants.update_parent,
+                tenant['uuid'],
+                new_parent_uuid,
+            )
+
     @fixtures.http.tenant()
     def test_put_parent(self, tenant):
         with self.client_in_subtenant() as (client, _, sub_tenant):

--- a/wazo_auth/database/queries/tenant.py
+++ b/wazo_auth/database/queries/tenant.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy import and_, exc, text
@@ -231,6 +231,11 @@ class TenantDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
                 if constraint == 'auth_tenant_domain_name_key':
                     raise exceptions.DomainAlreadyExistException(domain_names)
             raise
+
+    def update_parent(self, tenant_uuid, parent_uuid):
+        tenant = self.session.get(Tenant, str(tenant_uuid))
+        tenant.parent_uuid = parent_uuid
+        self.session.flush()
 
     def _tenant_query(self, top_tenant_uuid, scoping_tenant_uuid=None):
         if scoping_tenant_uuid is None:

--- a/wazo_auth/exceptions.py
+++ b/wazo_auth/exceptions.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from urllib.parse import urlencode
@@ -174,6 +174,13 @@ class UnauthorizedTenantwithChildrenDelete(APIException):
         )
         details = {'uuid': str(tenant_uuid)}
         super().__init__(400, msg, details, 'tenants')
+
+
+class DescendentTenantException(APIException):
+    def __init__(self, tenant_uuid, parent_uuid):
+        msg = f'Parent ({parent_uuid}) is a descendent of tenant: "{tenant_uuid}"'
+        details = {'uuid': str(tenant_uuid), 'parent_uuid': str(parent_uuid)}
+        super().__init__(409, msg, 'conflict', details, 'tenants')
 
 
 class UnknownEmailException(APIException):

--- a/wazo_auth/plugins/http/tenants/api.yml
+++ b/wazo_auth/plugins/http/tenants/api.yml
@@ -163,7 +163,29 @@ paths:
           description: System related error
           schema:
             $ref: '#/definitions/Error'
-
+  /tenants/{tenant_uuid}/parent/{parent_tenant_uuid}:
+    put:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      summary: Update tenant's parent
+      description: '**Required ACL:** `auth.tenants.{tenant_uuid}.parent.{parent_tenant_uuid}.update`'
+      operationId: updateTenantParent
+      tags:
+      - tenants
+      security:
+      - wazo_auth_token: []
+      parameters:
+        - $ref: '#/parameters/tenant_uuid'
+        - $ref: '#/parameters/parent_tenant_uuid'
+      responses:
+        '201':
+          description: Parent updated
+        '404':
+          description: Tenant or Parent not found
+          schema:
+            $ref: '#/definitions/Error'
 
 parameters:
   tenant_uuid:
@@ -171,6 +193,12 @@ parameters:
     in: path
     type: string
     description: The UUID of the tenant
+    required: true
+  parent_tenant_uuid:
+    name: parent_tenant_uuid
+    in: path
+    type: string
+    description: The UUID of the new parent tenant
     required: true
 definitions:
   TenantPostResponse:

--- a/wazo_auth/plugins/http/tenants/api.yml
+++ b/wazo_auth/plugins/http/tenants/api.yml
@@ -180,7 +180,7 @@ paths:
         - $ref: '#/parameters/tenant_uuid'
         - $ref: '#/parameters/parent_tenant_uuid'
       responses:
-        '201':
+        '204':
           description: Parent updated
         '404':
           description: Tenant or Parent not found

--- a/wazo_auth/plugins/http/tenants/http.py
+++ b/wazo_auth/plugins/http/tenants/http.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -126,3 +126,13 @@ class TenantDomains(BaseResource):
         response = {'total': total, 'items': domains}
 
         return response, 200
+
+
+class TenantParent(BaseResource):
+    @http.required_acl('auth.tenants.{tenant_uuid}.parent.{parent_tenant_uuid}.update')
+    def put(self, tenant_uuid, parent_tenant_uuid):
+        scoping_tenant = TenantDetector.autodetect()
+        self.tenant_service.update_parent(
+            scoping_tenant.uuid, tenant_uuid, parent_tenant_uuid
+        )
+        return '', 201

--- a/wazo_auth/plugins/http/tenants/http.py
+++ b/wazo_auth/plugins/http/tenants/http.py
@@ -135,4 +135,4 @@ class TenantParent(BaseResource):
         self.tenant_service.update_parent(
             scoping_tenant.uuid, tenant_uuid, parent_tenant_uuid
         )
-        return '', 201
+        return '', 204

--- a/wazo_auth/plugins/http/tenants/plugin.py
+++ b/wazo_auth/plugins/http/tenants/plugin.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from . import http
@@ -22,5 +22,10 @@ class Plugin:
         api.add_resource(
             http.TenantDomains,
             '/tenants/<uuid:tenant_uuid>/domains',
+            resource_class_args=args,
+        )
+        api.add_resource(
+            http.TenantParent,
+            '/tenants/<uuid:tenant_uuid>/parent/<uuid:parent_tenant_uuid>',
             resource_class_args=args,
         )

--- a/wazo_auth/services/tenant.py
+++ b/wazo_auth/services/tenant.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -164,3 +164,13 @@ class TenantService(BaseService):
 
         domains = self._dao.domain.get(str(tenant_uuid))
         return [{'name': domain.name, 'uuid': domain.uuid} for domain in domains]
+
+    def update_parent(self, scoping_tenant_uuid, tenant_uuid, parent_tenant_uuid):
+        visible_tenants = self.list_sub_tenants(scoping_tenant_uuid)
+        if str(tenant_uuid) not in visible_tenants:
+            raise exceptions.UnknownTenantException(tenant_uuid)
+
+        if str(parent_tenant_uuid) not in visible_tenants:
+            raise exceptions.UnknownTenantException(parent_tenant_uuid)
+
+        self._dao.tenant.update_parent(str(tenant_uuid), str(parent_tenant_uuid))

--- a/wazo_auth/services/tenant.py
+++ b/wazo_auth/services/tenant.py
@@ -173,4 +173,7 @@ class TenantService(BaseService):
         if str(parent_tenant_uuid) not in visible_tenants:
             raise exceptions.UnknownTenantException(parent_tenant_uuid)
 
+        if self._dao.tenant.is_subtenant(str(parent_tenant_uuid), str(tenant_uuid)):
+            raise exceptions.DescendentTenantException(tenant_uuid, parent_tenant_uuid)
+
         self._dao.tenant.update_parent(str(tenant_uuid), str(parent_tenant_uuid))

--- a/wazo_auth/services/tenant.py
+++ b/wazo_auth/services/tenant.py
@@ -166,11 +166,14 @@ class TenantService(BaseService):
         return [{'name': domain.name, 'uuid': domain.uuid} for domain in domains]
 
     def update_parent(self, scoping_tenant_uuid, tenant_uuid, parent_tenant_uuid):
-        visible_tenants = self.list_sub_tenants(scoping_tenant_uuid)
-        if str(tenant_uuid) not in visible_tenants:
+        if not self._dao.tenant.is_subtenant(
+            str(tenant_uuid), str(scoping_tenant_uuid)
+        ):
             raise exceptions.UnknownTenantException(tenant_uuid)
 
-        if str(parent_tenant_uuid) not in visible_tenants:
+        if not self._dao.tenant.is_subtenant(
+            str(parent_tenant_uuid), str(scoping_tenant_uuid)
+        ):
             raise exceptions.UnknownTenantException(parent_tenant_uuid)
 
         if self._dao.tenant.is_subtenant(str(parent_tenant_uuid), str(tenant_uuid)):


### PR DESCRIPTION
Depends-on: https://github.com/wazo-platform/wazo-auth-client/pull/64



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new endpoint that mutates tenant hierarchy in the database; incorrect ACL/scoping or loop checks could impact tenant isolation and integrity.
> 
> **Overview**
> Adds a new tenant API `PUT /tenants/{tenant_uuid}/parent/{parent_tenant_uuid}` (ACL-gated) to change a tenant’s `parent_uuid`, wiring it through the HTTP plugin, `TenantService.update_parent`, and a new DAO `update_parent`.
> 
> The service enforces scoping (both tenant and new parent must be visible under the requester) and prevents hierarchy loops by rejecting moves where the proposed parent is a descendant (new `DescendentTenantException` returning `409`). Integration tests and the changelog are updated accordingly, and the tenant ancestry query used by `is_subtenant` is adjusted to fix the recursive CTE join/labels.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ac140732f08c7c6c27627dbaebf889525cf6c10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->