### PR TITLE
WAZO-4406-disable-user-remove-sessions

### DIFF
--- a/integration_tests/suite/test_users.py
+++ b/integration_tests/suite/test_users.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
@@ -315,6 +315,28 @@ class TestUsers(base.APIIntegrationTest):
         body = {'username': 'foobaz', 'firstname': None, 'lastname': None}
         result = self.client.users.edit(user_uuid, **body)
         assert_that(result, has_entries(**body))
+
+    @fixtures.http.user(username='foo', password='secret', enabled=True)
+    def test_put_disable_remove_sessions(self, user):
+        user_client = self.make_auth_client('foo', 'secret')
+        token = user_client.token.new('wazo_user', expiration=60)['token']
+
+        self.client.users.edit(user['uuid'], enabled=True)
+        assert self.client.token.is_valid(token)
+        assert self.client.users.get_sessions(user['uuid'])['total'] != 0
+
+        self.client.users.edit(user['uuid'], lastname='random-edit')
+        assert self.client.token.is_valid(token)
+        assert self.client.users.get_sessions(user['uuid'])['total'] != 0
+
+        headers = {'name': 'auth_session_deleted'}
+        msg_accumulator = self.bus.accumulator(headers=headers)
+
+        self.client.users.edit(user['uuid'], enabled=False)
+        assert not self.client.token.is_valid(token)
+        assert self.client.users.get_sessions(user['uuid'])['total'] == 0
+        messages = msg_accumulator.accumulate(with_headers=True)
+        assert messages[0]['message']['name'] == headers['name']
 
     @fixtures.http.user()
     @fixtures.http.user(username='u2@example.com')

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ pyyaml==6.0
 pysaml2==7.0.1
 requests-oauthlib==1.3.0
 requests==2.28.1
+setuptools==66.1.1  # pysaml2 needs pkg_resources
 sqlalchemy==1.4.46
 stevedore==4.0.2
 tenacity==8.2.1

--- a/wazo_auth/controller.py
+++ b/wazo_auth/controller.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
@@ -163,7 +163,11 @@ class Controller:
         group_service = services.GroupService(self.dao)
         policy_service = services.PolicyService(self.dao)
         session_service = services.SessionService(self.dao, self._bus_publisher)
-        self._user_service = services.UserService(self.dao, self._tenant_service)
+        self._user_service = services.UserService(
+            self.dao,
+            self._bus_publisher,
+            self._tenant_service,
+        )
         self._token_service = services.TokenService(
             config, self.dao, self._bus_publisher, self._user_service
         )

--- a/wazo_auth/database/queries/session.py
+++ b/wazo_auth/database/queries/session.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy import and_, text
@@ -68,3 +68,16 @@ class SessionDAO(PaginatorMixin, BaseDAO):
         self.session.flush()
 
         return session_result, token_result
+
+    def delete_by_user(self, user_uuid):
+        query = (
+            self.session.query(Session.uuid)
+            .select_from(Token)
+            .join(Token.session)
+            .filter(Token.auth_id == str(user_uuid))
+        )
+        session_uuids = [row[0] for row in query.all()]
+        self.session.query(Session).filter(Session.uuid.in_(session_uuids)).delete()
+        self.session.flush()
+
+        return [{'uuid': uuid} for uuid in session_uuids]

--- a/wazo_auth/plugins/http/users/api.yml
+++ b/wazo_auth/plugins/http/users/api.yml
@@ -112,7 +112,11 @@ paths:
       produces:
         - application/json
       summary: Update an existing user
-      description: "**Required ACL**: `auth.users.{user_uuid}.update`"
+      description: |
+        **Required ACL**: `auth.users.{user_uuid}.update`
+
+        When disabling a user (`enabled: false`), all active sessions (i.e.
+        tokens) will be immediately revoked and can no longer be used.
       operationId: updateUser
       tags:
         - users

--- a/wazo_auth/tests/test_services.py
+++ b/wazo_auth/tests/test_services.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
@@ -20,6 +20,7 @@ from wazo_auth.config import _DEFAULT_CONFIG
 from wazo_auth.services.tenant import TenantService
 
 from .. import exceptions, services
+from ..bus import BusPublisher
 from ..database import queries
 from ..database.queries import (
     address,
@@ -228,9 +229,10 @@ class TestGroupService(BaseServiceTestCase):
 class TestUserService(BaseServiceTestCase):
     def setUp(self):
         super().setUp()
+        self.bus_publisher = Mock(BusPublisher)
         self.tenant_service = Mock(TenantService)
         self.service = services.UserService(
-            self.dao, self.tenant_service, encrypter=self.encrypter
+            self.dao, self.bus_publisher, self.tenant_service, encrypter=self.encrypter
         )
 
     def test_change_password(self):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes session/token revocation behavior in the user update path and adds bulk session deletion, which could impact active logins if the `enabled` flag is updated unexpectedly or incorrectly scoped.
> 
> **Overview**
> Disabling a user (`enabled: false`) now **immediately revokes all active sessions/tokens** for that user by deleting sessions via a new `SessionDAO.delete_by_user()` and publishing `SessionDeletedEvent` bus events from `UserService.update()`.
> 
> Wiring is updated so `UserService` receives a `BusPublisher`, the users API documentation now states the revocation behavior, and new unit/integration tests assert that tokens become invalid, sessions drop to zero, and an `auth_session_deleted` message is emitted. Adds `setuptools` to runtime requirements for `pysaml2` (`pkg_resources`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 454e077a44bc12a4e4977d6b9e05f9570d31161b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->