### PR TITLE
fix-pkg-resources

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ pyyaml==6.0
 pysaml2==7.0.1
 requests-oauthlib==1.3.0
 requests==2.28.1
+setuptools==66.1.1  # pysaml2 needs pkg_resources
 sqlalchemy==1.4.46
 stevedore==4.0.2
 tenacity==8.2.1


### PR DESCRIPTION
why: saml2 uses pkg_resources and latest setuptools version (82) remove
this deprecated module (now included in importlib built-in module)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency pin to avoid a known upstream breaking change; minimal behavioral impact beyond build/runtime dependency resolution.
> 
> **Overview**
> Pins `setuptools==66.1.1` in `requirements.txt` to ensure `pysaml2` can still import `pkg_resources` (removed in newer `setuptools` releases).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 435f93f006ad64df28e573f3eedef1b165b045c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->