### PR TITLE
WAZO-4404-update-password-remove-sessions

### DIFF
--- a/wazo_auth/plugins/http/password_reset/api.yml
+++ b/wazo_auth/plugins/http/password_reset/api.yml
@@ -34,7 +34,10 @@ paths:
       description: |
         **Required ACL**: `auth.users.password.reset.{user_uuid}.create`
 
-        Set a new password for the user after the user used the GET on the reset URL
+        Set a new password for the user after the user used the GET on the reset URL.
+
+        All active sessions (i.e. tokens) will be immediately revoked and can no longer be used.
+        Existing refresh tokens are not affected and remain valid.
       operationId: reset_password_change
       tags:
         - users

--- a/wazo_auth/plugins/http/users/api.yml
+++ b/wazo_auth/plugins/http/users/api.yml
@@ -149,7 +149,11 @@ paths:
         - users
       security:
         - wazo_auth_token: []
-      description: "**Required ACL**: `auth.users.{user_uuid}.password.update`"
+      description: |
+        **Required ACL**: `auth.users.{user_uuid}.password.update`
+
+        All active sessions (i.e. tokens) will be immediately revoked and can no longer be used.
+        Existing refresh tokens are not affected and remain valid.
       summary: "Change the user's password"
       parameters:
         - $ref: '#/parameters/user_uuid'

--- a/wazo_auth/services/user.py
+++ b/wazo_auth/services/user.py
@@ -65,6 +65,8 @@ class UserService(BaseService):
 
         salt, hash_ = self._encrypter.encrypt_password(new_password)
         self._dao.user.change_password(user_uuid, salt, hash_)
+        sessions = self._dao.session.delete_by_user(user_uuid)
+        self._publish_session_deleted_events(user, sessions)
 
     def _find_main_email(self, user):
         for email in user['emails']:
@@ -82,6 +84,8 @@ class UserService(BaseService):
 
         for user in users:
             self._dao.user.change_password(user['uuid'], salt=None, hash_=None)
+            sessions = self._dao.session.delete_by_user(user['uuid'])
+            self._publish_session_deleted_events(user, sessions)
             return user
 
     def _publish_session_deleted_events(self, user, sessions):

--- a/wazo_auth/tests/test_services.py
+++ b/wazo_auth/tests/test_services.py
@@ -236,6 +236,7 @@ class TestUserService(BaseServiceTestCase):
         )
 
     def test_change_password(self):
+        self.session_dao.delete_by_user.return_value = []
         self.user_dao.list_.return_value = []
         assert_that(
             calling(self.service.change_password).with_args(s.uuid, s.old, s.new),
@@ -259,6 +260,7 @@ class TestUserService(BaseServiceTestCase):
         self.user_dao.change_password.assert_called_once_with(s.uuid, s.salt, s.hash_)
 
     def test_change_password_external_auth(self):
+        self.session_dao.delete_by_user.return_value = []
         self.user_dao.list_.return_value = [
             {'username': 'foobar', 'uuid': s.uuid, 'authentication_method': 'saml'}
         ]
@@ -301,6 +303,7 @@ class TestUserService(BaseServiceTestCase):
         self.user_dao.change_password.assert_called_once_with(s.uuid, s.salt, s.hash_)
 
     def test_delete_password(self):
+        self.session_dao.delete_by_user.return_value = []
         self.user_dao.list_.return_value = []
         assert_that(
             calling(self.service.delete_password).with_args(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches authentication session lifecycle by deleting user sessions and publishing `auth_session_deleted` events on password changes, which could inadvertently log out users if misapplied. Changes are localized but affect security-sensitive behavior around tokens and session invalidation.
> 
> **Overview**
> Password updates now **immediately revoke all active sessions**: `UserService.change_password` and `UserService.delete_password` delete all sessions for the user and publish session-deletion events.
> 
> API docs for `PUT /users/{user_uuid}/password` and `POST /users/password/reset` are updated to explicitly state that active tokens are revoked (while refresh tokens remain valid), and integration/unit tests are added/adjusted to assert token invalidation, empty session lists, and `auth_session_deleted` bus messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d2f59ce1471013e897b2772d163b73827c35a53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->