### PR TITLE
[ITEM-209] WP-1983-force-auth-cli-password

### DIFF
--- a/integration_tests/assets/docker-compose.bootstrap.override.yml
+++ b/integration_tests/assets/docker-compose.bootstrap.override.yml
@@ -1,0 +1,8 @@
+services:
+  sync:
+    depends_on:
+      - auth
+      - postgres
+      - rabbitmq
+    environment:
+      TARGETS: "auth:9497 postgres:5432 rabbitmq:5672"

--- a/integration_tests/suite/conftest.py
+++ b/integration_tests/suite/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
@@ -58,6 +58,15 @@ def metadata():
         yield
     finally:
         asset.MetadataAssetLaunchingTestCase.tearDownClass()
+
+
+@pytest.fixture(scope='package')
+def bootstrap():
+    asset.BootstrapAssetLaunchingTestCase.setUpClass()
+    try:
+        yield
+    finally:
+        asset.BootstrapAssetLaunchingTestCase.tearDownClass()
 
 
 @pytest.fixture(autouse=True, scope='function')

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -162,6 +162,10 @@ class MetadataAssetLaunchingTestCase(BaseAssetLaunchingTestCase):
     asset = 'metadata'
 
 
+class BootstrapAssetLaunchingTestCase(BaseAssetLaunchingTestCase):
+    asset = 'bootstrap'
+
+
 class DAOTestCase(unittest.TestCase):
     unknown_uuid = '00000000-0000-0000-0000-000000000000'
     asset_cls = DBAssetLaunchingTestCase
@@ -566,6 +570,14 @@ class SAMLIntegrationTest(BaseIntegrationTest):
     asset_cls = SAMLAssetLaunchingTestCase
     username = 'admin'
     password = 's3cre7'
+
+
+class BootstrapIntegrationTest(unittest.TestCase):
+    asset_cls = BootstrapAssetLaunchingTestCase
+
+    @classmethod
+    def make_auth_client(cls, *args, **kwargs):
+        return cls.asset_cls.make_auth_client(*args, **kwargs)
 
 
 @contextmanager

--- a/integration_tests/suite/test_bootstrap.py
+++ b/integration_tests/suite/test_bootstrap.py
@@ -1,0 +1,44 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import yaml
+
+from .helpers import base
+
+CLI_CONFIG_PATH = '/root/.config/wazo-auth-cli/050-credentials.yml'
+
+
+@base.use_asset('bootstrap')
+class TestBootstrapComplete(base.BootstrapIntegrationTest):
+    def setUp(self):
+        self._run_bootstrap_complete()
+
+    def _run_bootstrap_complete(self):
+        self.asset_cls.docker_exec(['wazo-auth-bootstrap', 'complete'], 'auth')
+
+    def _read_cli_config(self):
+        content = self.asset_cls.docker_exec(['cat', CLI_CONFIG_PATH], 'auth').decode(
+            'utf-8'
+        )
+        return yaml.safe_load(content)
+
+    def test_complete_is_idempotent(self):
+        config_before = self._read_cli_config()
+
+        self._run_bootstrap_complete()
+
+        config_after = self._read_cli_config()
+        assert config_before == config_after
+
+    def test_complete_resets_password_when_config_file_is_missing(self):
+        self.asset_cls.docker_exec(['rm', CLI_CONFIG_PATH], 'auth')
+
+        self._run_bootstrap_complete()
+
+        config = self._read_cli_config()
+        username = config['auth']['username']
+        password = config['auth']['password']
+        client = self.make_auth_client(username, password)
+        token = client.token.new(expiration=60)
+        assert token['token']
+        client.token.revoke(token['token'])

--- a/wazo_auth/bootstrap.py
+++ b/wazo_auth/bootstrap.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import argparse
@@ -112,6 +112,26 @@ def bootstrap_initial_user(
     create_initial_user(username, password, purpose, authentication_method, policy_slug)
 
 
+def reset_or_create_initial_user(
+    username, password, purpose, authentication_method, policy_slug
+):
+    dao = queries.DAO.from_defaults()
+    user_service = services.UserService(dao)
+
+    users = user_service.list_users(username=username)
+    if users:
+        encrypter = services.PasswordEncrypter()
+        user_uuid = users[0]['uuid']
+        salt, hash_ = encrypter.encrypt_password(password)
+        dao.user.change_password(user_uuid, salt, hash_)
+        dao.session.delete_by_user(user_uuid)
+        commit_or_rollback()
+    else:
+        create_initial_user(
+            username, password, purpose, authentication_method, policy_slug
+        )
+
+
 def create_initial_user(
     username, password, purpose, authentication_method, policy_slug
 ):
@@ -155,8 +175,8 @@ def complete():
         )
     else:
         password = random_string(28)
-        bootstrap_initial_user(
-            database_uri,
+        init_db(database_uri)
+        reset_or_create_initial_user(
             USERNAME,
             password,
             PURPOSE,


### PR DESCRIPTION
Why: after a VM migration or similar event, the wazo-auth-cli config
file can disappear while the user still exists in the DB. Running
wazo-auth-bootstrap complete would fail with "user already exists with
different credential" and leave the system unrecoverable without manual
DB intervention.

Reset the DB password and rewrite the config file instead of raising.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `wazo-auth-bootstrap complete` behavior to forcibly reset an existing internal user’s password and revoke sessions, which impacts authentication state and could lock out unexpected users if misapplied. Logic is small but touches credential and session handling.
> 
> **Overview**
> Makes `wazo-auth-bootstrap complete` resilient to missing `wazo-auth-cli` credentials by **resetting the existing internal user password (and revoking its sessions) or creating the user**, then rewriting the CLI config instead of failing with a credential mismatch.
> 
> Adds a new `bootstrap` integration-test asset plus `test_bootstrap.py` to verify `complete` is idempotent and that deleting the CLI config triggers password reset and produces working credentials.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8625e0b1ae48922b8158003afe9a307b2584a50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->