### PR TITLE
fix incorrect spec for GET /saml/acs logout response endpoint

### DIFF
--- a/wazo_auth/plugins/http/saml/api.yml
+++ b/wazo_auth/plugins/http/saml/api.yml
@@ -129,19 +129,23 @@ paths:
       description: |
         Processes the IdP response to logout request and confirms the logout by
         a redirect to the `redirect_url` provided during the login phase
-        with logout confirmation un the URL's query param.
+        with logout confirmation in the URL's query param.
       summary: Handles the logout response from the IDP
       operationId: samlLogoutResponse
       tags:
       - token
       - saml
       parameters:
-      - description: SAML SSO Logout data
-        in: body
-        name: body
+      - in: query
         required: true
-        schema:
-          $ref: '#/definitions/SAMLIdpLogoutResponse'
+        name: SAMLResponse
+        type: string
+        description: Encoded SAML XML response to logout request
+      - in: query
+        required: true
+        name: RelayState
+        type: string
+        description: Relay state parameter
       responses:
         '201':
           description: |
@@ -199,16 +203,3 @@ definitions:
         description: |
           The URL that the client should open to complete the logout.
         type: string
-
-  SAMLIdpLogoutResponse:
-    properties:
-      SAMLLogoutResponse:
-        description: Encoded SAML XML response to logout request
-        type: string
-      RelayState:
-        description: Relay state parameter
-        type: string
-    required:
-    - SAMLLogoutResponse
-    - RelayState
-    type: object


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to the OpenAPI spec for the SAML logout callback, correcting parameter placement/naming without altering runtime logic.
> 
> **Overview**
> Fixes the OpenAPI spec for `GET /saml/sls` (SAML logout response handler) to accept `SAMLResponse` and `RelayState` as required **query** parameters instead of a body payload.
> 
> Also removes the unused `SAMLIdpLogoutResponse` schema and corrects a small typo in the endpoint description.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46cd49a114a77ee668ea3b3f87f157050eb17680. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->