### PR TITLE
typing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,11 @@ repos:
     rev: 1.1.1
     hooks:
       - id: wazo-copyright-check
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.19.1
+    hooks:
+      - id: mypy
+        language_version: '3.11'
+        additional_dependencies:
+          - 'sqlalchemy==1.4.46'
+          - 'sqlalchemy2-stubs'

--- a/integration_tests/suite/test_db_token.py
+++ b/integration_tests/suite/test_db_token.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import time
@@ -164,6 +164,29 @@ class TestTokenDAO(base.DAOTestCase):
         assert_that(
             db_tokens,
             empty(),
+        )
+
+    def test_expiring_query_returns_empty_dict_when_metadata_is_null(self):
+        session = models.Session(tenant_uuid=self.top_tenant_uuid)
+        self.session.add(session)
+        self.session.flush()
+        token = models.Token(
+            auth_id='test',
+            session_uuid=session.uuid,
+            issued_t=int(time.time()),
+            expire_t=int(time.time()) - 1,
+            metadata_=None,
+        )
+        self.session.add(token)
+        self.session.flush()
+
+        tokens, _ = next(
+            self._token_dao.get_tokens_and_sessions_about_to_expire(0, batch_size=10)
+        )
+
+        assert_that(
+            tokens,
+            has_items(has_entries(uuid=token.uuid, metadata=equal_to({}))),
         )
 
     @fixtures.db.token(expiration=0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,32 @@ py_version = 311
 
 [tool.pytest]
 testpaths = ["wazo_auth"]
+
+[tool.mypy]
+python_version = "3.11"
+plugins = ["sqlalchemy.ext.mypy.plugin"]
+follow_imports = "silent"
+ignore_missing_imports = true
+show_error_codes = true
+check_untyped_defs = true
+warn_unused_configs = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+warn_unused_ignores = true
+strict_equality = true
+extra_checks = true
+no_warn_no_return = true
+
+# avoid conflicts between modules of the same name e.g. setup.py
+explicit_package_bases = true
+
+# opt-in mode, disable when everything is sufficiently typed
+ignore_errors = true
+
+# extend as modules are typed, eventually remove or replace with exclusions
+[[tool.mypy.overrides]]
+module = [
+    "wazo_auth.database.queries.token",
+]
+ignore_errors = false

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ pysaml2==7.0.1
 requests-oauthlib==1.3.0
 requests==2.28.1
 setuptools==66.1.1  # pysaml2 needs pkg_resources
-sqlalchemy==1.4.46
+sqlalchemy==1.4.46  # keep in sync with .pre-commit-config.yaml
 stevedore==4.0.2
 tenacity==8.2.1
 unidecode==1.3.6

--- a/wazo_auth/database/queries/token.py
+++ b/wazo_auth/database/queries/token.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
@@ -8,7 +8,8 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Bundle
 from sqlalchemy.sql import cast
 
-from ... import exceptions
+from wazo_auth import exceptions
+
 from ..models import Session, Tenant
 from ..models import Token as TokenModel
 from .base import BaseDAO

--- a/wazo_auth/database/queries/token.py
+++ b/wazo_auth/database/queries/token.py
@@ -1,8 +1,11 @@
 # Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import json
 import time
+from collections.abc import Iterator
+from typing import Any, TypedDict
 
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Bundle
@@ -15,8 +18,45 @@ from ..models import Token as TokenModel
 from .base import BaseDAO
 
 
+class TokenIdentity(TypedDict):
+    uuid: str
+    auth_id: str
+
+
+class SessionIdentity(TypedDict):
+    uuid: str
+    tenant_uuid: str
+
+
+class TokenRecord(TokenIdentity):
+    pbx_user_uuid: str | None
+    xivo_uuid: str | None
+    issued_t: int
+    expire_t: int
+    acl: list[str]
+    metadata: dict[str, Any]
+    session_uuid: str
+    remote_addr: str | None
+    user_agent: str | None
+    refresh_token_uuid: str | None
+
+
+class ExpiringTokenRow(TokenIdentity):
+    session_uuid: str
+    metadata: dict[str, Any]
+
+
+class ExpiringSessionRow(TypedDict):
+    uuid: str
+
+
 class TokenDAO(BaseDAO):
-    def create(self, body, session_body, refresh_token_uuid=None):
+    def create(
+        self,
+        body: dict[str, Any],
+        session_body: dict[str, Any],
+        refresh_token_uuid: str | None = None,
+    ) -> tuple[str, str]:
         serialized_metadata = json.dumps(body.get('metadata', {}))
         token = TokenModel(
             auth_id=body['auth_id'],
@@ -37,57 +77,64 @@ class TokenDAO(BaseDAO):
 
         self.session.add(token)
         self.session.flush()
+        assert token.uuid is not None and token.session_uuid is not None
         return token.uuid, token.session_uuid
 
-    def _get_default_tenant_uuid(self):
+    def _get_default_tenant_uuid(self) -> str:
         filter_ = Tenant.uuid == Tenant.parent_uuid
         return self.session.query(Tenant).filter(filter_).first().uuid
 
-    def get(self, token_uuid):
+    def get(self, token_uuid: str) -> TokenRecord:
         token = self.session.get(TokenModel, str(token_uuid))
         if token:
-            return {
-                'uuid': token.uuid,
-                'auth_id': token.auth_id,
-                'pbx_user_uuid': token.pbx_user_uuid,
-                'xivo_uuid': token.xivo_uuid,
-                'issued_t': token.issued_t,
-                'expire_t': token.expire_t,
-                'acl': token.acl,
-                'metadata': json.loads(token.metadata_) if token.metadata_ else {},
-                'session_uuid': token.session_uuid,
-                'remote_addr': token.remote_addr,
-                'user_agent': token.user_agent,
-                'refresh_token_uuid': token.refresh_token_uuid,
-            }
+            return TokenRecord(
+                uuid=token.uuid,
+                auth_id=token.auth_id,
+                pbx_user_uuid=token.pbx_user_uuid,
+                xivo_uuid=token.xivo_uuid,
+                issued_t=token.issued_t,
+                expire_t=token.expire_t,
+                acl=token.acl,
+                metadata=json.loads(token.metadata_) if token.metadata_ else {},
+                session_uuid=token.session_uuid,
+                remote_addr=token.remote_addr,
+                user_agent=token.user_agent,
+                refresh_token_uuid=token.refresh_token_uuid,
+            )
 
         raise exceptions.UnknownTokenException()
 
-    def delete(self, token_uuid):
+    # TODO: change type signature, use None instead of {} when token not found
+    def delete(
+        self, token_uuid: str
+    ) -> tuple[TokenIdentity | dict[str, Any], SessionIdentity | dict[str, Any]]:
         filter_ = TokenModel.uuid == str(token_uuid)
 
-        session_result = {}
+        session_result: SessionIdentity | dict[str, Any] = {}
         token = self.session.query(TokenModel).filter(filter_).first()
         if not token:
             return {}, {}
 
         session = token.session
         if len(session.tokens) == 1:
-            session_result = {
-                'uuid': session.uuid,
-                'tenant_uuid': session.tenant_uuid,
-            }
+            session_result = SessionIdentity(
+                uuid=session.uuid,
+                tenant_uuid=session.tenant_uuid,
+            )
             self.session.delete(session)
 
-        token_result = {'uuid': token.uuid, 'auth_id': token.auth_id}
+        token_result = TokenIdentity(uuid=token.uuid, auth_id=token.auth_id)
         self.session.query(TokenModel).filter(filter_).delete()
         self.session.flush()
 
         return token_result, session_result
 
     def _get_tokens_and_sessions_by_expiration(
-        self, time_remaining, limit=None, offset=None
-    ):
+        self,
+        time_remaining: float,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> tuple[list[ExpiringTokenRow], list[ExpiringSessionRow]] | None:
         query = (
             self.session.query(
                 Bundle(
@@ -113,12 +160,22 @@ class TokenDAO(BaseDAO):
         results = query.all()
         if not results:
             return None
-        tokens = [result.token._asdict() for result in results]
-        sessions = [result.session._asdict() for result in results]
+        tokens = [
+            ExpiringTokenRow(
+                uuid=result.token.uuid,
+                auth_id=result.token.auth_id,
+                session_uuid=result.token.session_uuid,
+                metadata=result.token.metadata,
+            )
+            for result in results
+        ]
+        sessions = [ExpiringSessionRow(uuid=result.session.uuid) for result in results]
 
         return tokens, sessions
 
-    def purge_expired_tokens_and_sessions(self, batch_size=5_000):
+    def purge_expired_tokens_and_sessions(
+        self, batch_size: int = 5_000
+    ) -> Iterator[tuple[list[ExpiringTokenRow], list[ExpiringSessionRow]]]:
         while batch := self._get_tokens_and_sessions_by_expiration(0, batch_size):
             tokens, sessions = batch
 
@@ -132,7 +189,9 @@ class TokenDAO(BaseDAO):
             if len(tokens) < batch_size:
                 return
 
-    def get_tokens_and_sessions_about_to_expire(self, time_remaining, batch_size=5_000):
+    def get_tokens_and_sessions_about_to_expire(
+        self, time_remaining: float, batch_size: int = 5_000
+    ) -> Iterator[tuple[list[ExpiringTokenRow], list[ExpiringSessionRow]]]:
         offset = 0
         while batch := self._get_tokens_and_sessions_by_expiration(
             time_remaining, batch_size, offset

--- a/wazo_auth/database/queries/token.py
+++ b/wazo_auth/database/queries/token.py
@@ -82,7 +82,7 @@ class TokenDAO(BaseDAO):
 
     def _get_default_tenant_uuid(self) -> str:
         filter_ = Tenant.uuid == Tenant.parent_uuid
-        return self.session.query(Tenant).filter(filter_).first().uuid
+        return self.session.query(Tenant).filter(filter_).one().uuid
 
     def get(self, token_uuid: str) -> TokenRecord:
         token = self.session.get(TokenModel, str(token_uuid))

--- a/wazo_auth/database/queries/token.py
+++ b/wazo_auth/database/queries/token.py
@@ -165,7 +165,9 @@ class TokenDAO(BaseDAO):
                 uuid=result.token.uuid,
                 auth_id=result.token.auth_id,
                 session_uuid=result.token.session_uuid,
-                metadata=result.token.metadata,
+                metadata=result.token.metadata
+                if result.token.metadata is not None
+                else {},
             )
             for result in results
         ]


### PR DESCRIPTION
- **token dao: fix 3-level relative import**
- **typing: targeted config**
- **wazo_auth.database.queries.token: typing**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly typing/tooling, but it changes DAO runtime behavior (NULL metadata normalization and `.one()` tenant lookup) which could raise in unexpected DB states or affect cleanup/notification jobs.
> 
> **Overview**
> Adds **mypy** to pre-commit and introduces a strict-ish `pyproject.toml` mypy configuration, initially enabling checks only for `wazo_auth.database.queries.token` (global `ignore_errors=true`).
> 
> Refactors `TokenDAO` (`wazo_auth/database/queries/token.py`) to use `TypedDict`-based return types, fixes the import to `from wazo_auth import exceptions`, and adjusts query/result shaping so expiring-token rows always return `metadata` as `{}` when the DB value is NULL (covered by a new integration test). It also tightens default-tenant lookup from `.first()` to `.one()` and adds runtime asserts after flush for UUIDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99d7cd22b9e904864dc9144e1aeaa6255601004b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->