### PR TITLE
TASK 261 inform session revocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * `POST /0.1/token` (`Wazo-Session-Type: mobile`, `access_type=offline`):
     * now revokes any pre-existing mobile refresh tokens and their sessions for the user, in order to guarantee a single active mobile client per user;
     * always issues a new refresh token, revoking any existing refresh token (and associated sessions) for the provided client_id (non-mobile requests may still return an existing refresh token)
-* `POST /0.1/token`: response now includes a `Wazo-Sessions-Revoked` header reporting the number of pre-existing sessions revoked by this login
+* `POST /0.1/token`: response now includes a `Wazo-Sessions-Revoked` header reporting the number of pre-existing sessions revoked by this login (currently may only be non-zero for mobile offline logins)
 
 ## 26.03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * `POST /0.1/token` (`Wazo-Session-Type: mobile`, `access_type=offline`):
     * now revokes any pre-existing mobile refresh tokens and their sessions for the user, in order to guarantee a single active mobile client per user;
     * always issues a new refresh token, revoking any existing refresh token (and associated sessions) for the provided client_id (non-mobile requests may still return an existing refresh token)
+* `POST /0.1/token`: response now includes a `Wazo-Sessions-Revoked` header reporting the number of pre-existing sessions revoked by this login
 
 ## 26.03
 

--- a/integration_tests/suite/test_token.py
+++ b/integration_tests/suite/test_token.py
@@ -547,6 +547,76 @@ class TestTokens(base.APIIntegrationTest):
             ),
         )
 
+    def _post_token_raw(
+        self,
+        username,
+        password,
+        session_type=None,
+        **body,
+    ):
+        encoded_credentials = b64encode(f'{username}:{password}'.encode())
+        headers = {
+            'Authorization': b'Basic ' + encoded_credentials,
+            'Content-Type': 'application/json',
+        }
+        if session_type is not None:
+            headers['Wazo-Session-Type'] = session_type
+        return requests.post(
+            self.client.token.base_url,
+            headers=headers,
+            json=body,
+        )
+
+    @fixtures.http.user(username='foo', password='bar')
+    def test_sessions_revoked_header_zero_on_vanilla_login(self, user):
+        response = self._post_token_raw('foo', 'bar', expiration=1)
+
+        assert_that(response.status_code, equal_to(200))
+        assert_that(response.headers, has_entry('Wazo-Sessions-Revoked', '0'))
+
+    @fixtures.http.user(username='foo', password='bar')
+    def test_sessions_revoked_header_one_on_cross_client_mobile_incumbent(self, user):
+        self._post_token(
+            'foo',
+            'bar',
+            session_type='mobile',
+            access_type='offline',
+            client_id='mobile-device-1',
+        )
+
+        response = self._post_token_raw(
+            'foo',
+            'bar',
+            session_type='mobile',
+            access_type='offline',
+            client_id='mobile-device-2',
+        )
+
+        assert_that(response.status_code, equal_to(200))
+        assert_that(response.headers, has_entry('Wazo-Sessions-Revoked', '1'))
+
+    @fixtures.http.user(username='foo', password='bar')
+    def test_sessions_revoked_header_one_on_same_client_id_mobile_relogin(self, user):
+        client_id = 'mobile-device'
+        self._post_token(
+            'foo',
+            'bar',
+            session_type='mobile',
+            access_type='offline',
+            client_id=client_id,
+        )
+
+        response = self._post_token_raw(
+            'foo',
+            'bar',
+            session_type='mobile',
+            access_type='offline',
+            client_id=client_id,
+        )
+
+        assert_that(response.status_code, equal_to(200))
+        assert_that(response.headers, has_entry('Wazo-Sessions-Revoked', '1'))
+
     @fixtures.http.user(username='foo', password='bar')
     def test_new_non_mobile_refresh_token_does_not_terminate_mobile(self, user):
         mobile_client_id = 'mobile-device-1'

--- a/wazo_auth/database/queries/token.py
+++ b/wazo_auth/database/queries/token.py
@@ -104,14 +104,6 @@ class TokenDAO(BaseDAO):
 
         raise exceptions.UnknownTokenException()
 
-    def list_by_refresh_token(self, refresh_token_uuid: str) -> list[TokenIdentity]:
-        filter_ = TokenModel.refresh_token_uuid == str(refresh_token_uuid)
-        query = self.session.query(TokenModel).filter(filter_)
-        return [
-            TokenIdentity(uuid=token.uuid, auth_id=token.auth_id)
-            for token in query.all()
-        ]
-
     # TODO: change type signature, use None instead of {} when token not found
     def delete(
         self, token_uuid: str

--- a/wazo_auth/plugins/http/tokens/api.yml
+++ b/wazo_auth/plugins/http/tokens/api.yml
@@ -79,6 +79,10 @@ paths:
           description: "The created token's data"
           schema:
             $ref: '#/definitions/Token'
+          headers:
+            Wazo-Sessions-Revoked:
+              description: Number of pre-existing sessions revoked as a side effect of this login.
+              type: integer
         '400':
           description: Invalid expiration or missing field
           schema:

--- a/wazo_auth/plugins/http/tokens/http.py
+++ b/wazo_auth/plugins/http/tokens/http.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -217,7 +217,9 @@ class Tokens(BaseResource):
             logger.debug('authentication failed: %s', e)
             return http._error(401, 'Authentication Failed')
 
-        token = self._token_service.new_token(backend, login, args)
+        token, revoked_sessions_count = self._token_service.new_token(
+            backend, login, args
+        )
         logger.info(
             'Successful login: %s got token %s from %s using agent "%s"',
             login,
@@ -231,7 +233,11 @@ class Tokens(BaseResource):
             )
             self._saml_service.invalidate_saml_session_id(args.get('saml_session_id'))
 
-        return {'data': token.to_dict()}, 200
+        return (
+            {'data': token.to_dict()},
+            200,
+            {'Wazo-Sessions-Revoked': str(revoked_sessions_count)},
+        )
 
 
 class Token(BaseResource):

--- a/wazo_auth/services/token.py
+++ b/wazo_auth/services/token.py
@@ -89,21 +89,21 @@ class TokenService(BaseService):
             )
         )
 
-    def purge_refresh_token_and_sessions(self, refresh_token_uuid: str) -> None:
+    def purge_refresh_token_and_sessions(self, refresh_token_uuid: str) -> int:
         refresh_token = self._dao.refresh_token.get_by_uuid(refresh_token_uuid)
-        self._purge_refresh_token_and_sessions(refresh_token)
+        return self._purge_refresh_token_and_sessions(refresh_token)
 
     def purge_refresh_token_and_sessions_by_client_id(
         self, user_uuid: str, client_id: str
-    ) -> None:
+    ) -> int:
         refresh_token_uuid = self._dao.refresh_token.get_existing_refresh_token(
             client_id, user_uuid
         )
         if not refresh_token_uuid:
             raise UnknownRefreshToken(client_id)
-        self.purge_refresh_token_and_sessions(refresh_token_uuid)
+        return self.purge_refresh_token_and_sessions(refresh_token_uuid)
 
-    def _purge_refresh_token_and_sessions(self, refresh_token: dict) -> None:
+    def _purge_refresh_token_and_sessions(self, refresh_token: dict) -> int:
         rt_uuid = refresh_token['uuid']
         deleted_session_uuids = self._dao.session.delete_by_refresh_token_uuid(rt_uuid)
         logger.debug(
@@ -134,6 +134,7 @@ class TokenService(BaseService):
                 refresh_token['user_uuid'],
             )
         )
+        return len(deleted_session_uuids)
 
     def list_refresh_tokens(
         self, scoping_tenant_uuid=None, recurse=False, **search_params
@@ -144,6 +145,8 @@ class TokenService(BaseService):
         return self._dao.refresh_token.list_(**search_params)
 
     def new_token(self, backend: BaseAuthenticationBackend, login, args):
+        revoked_sessions_count = 0
+
         metadata = backend.get_metadata(login, args)
         logger.debug('fresh token metadata for %s: %s', login, metadata)
 
@@ -217,8 +220,10 @@ class TokenService(BaseService):
                         body['user_uuid'],
                         body['client_id'],
                     )
-                    self.purge_refresh_token_and_sessions_by_client_id(
-                        body['user_uuid'], body['client_id']
+                    revoked_sessions_count += (
+                        self.purge_refresh_token_and_sessions_by_client_id(
+                            body['user_uuid'], body['client_id']
+                        )
                     )
                     refresh_token = self._create_refresh_token(body, tenant_uuid)
                 else:
@@ -240,7 +245,7 @@ class TokenService(BaseService):
                     "mobile offline login: cleaning up existing mobile sessions for user %s",
                     metadata['uuid'],
                 )
-                self._terminate_incumbent_mobile_sessions(
+                revoked_sessions_count += self._terminate_incumbent_mobile_sessions(
                     metadata['uuid'], refresh_token
                 )
 
@@ -260,7 +265,7 @@ class TokenService(BaseService):
         )
         self._bus_publisher.publish(event)
 
-        return token
+        return token, revoked_sessions_count
 
     def _create_refresh_token(self, body: dict, tenant_uuid: str | None) -> str:
         refresh_token = self._dao.refresh_token.create(body)
@@ -276,13 +281,17 @@ class TokenService(BaseService):
 
     def _terminate_incumbent_mobile_sessions(
         self, user_uuid: str, new_refresh_token_uuid: str
-    ) -> None:
+    ) -> int:
         existing = self._dao.refresh_token.list_(user_uuid=user_uuid, mobile=True)
         logger.debug("%d mobile refresh tokens for user %s", len(existing), user_uuid)
+        revoked_sessions_count = 0
         for incumbent in existing:
             if incumbent['uuid'] == new_refresh_token_uuid:
                 continue
-            self.purge_refresh_token_and_sessions(incumbent['uuid'])
+            revoked_sessions_count += self.purge_refresh_token_and_sessions(
+                incumbent['uuid']
+            )
+        return revoked_sessions_count
 
     def new_token_internal(self, expiration=None, acl=None):
         expiration = expiration if expiration is not None else self._default_expiration

--- a/wazo_auth/tests/test_services.py
+++ b/wazo_auth/tests/test_services.py
@@ -542,8 +542,11 @@ class TestTokenServicePurgeRefreshTokenAndSessions(BaseServiceTestCase):
             'session-2',
         ]
 
-        self.service.purge_refresh_token_and_sessions(self.REFRESH_TOKEN_UUID)
+        revoked_count = self.service.purge_refresh_token_and_sessions(
+            self.REFRESH_TOKEN_UUID
+        )
 
+        assert_that(revoked_count, equal_to(2))
         self.refresh_token_dao.get_by_uuid.assert_called_once_with(
             self.REFRESH_TOKEN_UUID
         )
@@ -580,8 +583,11 @@ class TestTokenServicePurgeRefreshTokenAndSessions(BaseServiceTestCase):
     def test_purge_refresh_token_and_sessions_with_no_active_sessions(self):
         self.session_dao.delete_by_refresh_token_uuid.return_value = []
 
-        self.service.purge_refresh_token_and_sessions(self.REFRESH_TOKEN_UUID)
+        revoked_count = self.service.purge_refresh_token_and_sessions(
+            self.REFRESH_TOKEN_UUID
+        )
 
+        assert_that(revoked_count, equal_to(0))
         self.session_dao.delete_by_refresh_token_uuid.assert_called_once_with(
             self.REFRESH_TOKEN_UUID
         )
@@ -595,10 +601,11 @@ class TestTokenServicePurgeRefreshTokenAndSessions(BaseServiceTestCase):
     def test_purge_refresh_token_and_sessions_by_client_id(self):
         self.session_dao.delete_by_refresh_token_uuid.return_value = ['session-1']
 
-        self.service.purge_refresh_token_and_sessions_by_client_id(
+        revoked_count = self.service.purge_refresh_token_and_sessions_by_client_id(
             self.USER_UUID, self.CLIENT_ID
         )
 
+        assert_that(revoked_count, equal_to(1))
         self.refresh_token_dao.get_existing_refresh_token.assert_called_once_with(
             self.CLIENT_ID, self.USER_UUID
         )


### PR DESCRIPTION
- **TokenDAO: Removed unused method list_by_refresh_token**
- **token: surface revoked sessions count in response header**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `POST /0.1/token` response shape by adding a new header and refactors token creation to track and return how many sessions were revoked, which could affect clients/proxies that assume a fixed response format. Logic touches login/session revocation paths for mobile offline tokens, so regressions could impact session lifecycle behavior.
> 
> **Overview**
> `POST /0.1/token` now returns a `Wazo-Sessions-Revoked` response header containing the number of pre-existing sessions revoked as a side effect of the login (primarily for mobile `access_type=offline`).
> 
> To support this, `TokenService.new_token()` and refresh-token purge helpers now return a revocation count (instead of `None`), and the HTTP token endpoint plumbs that value into the response; OpenAPI (`tokens/api.yml`), changelog, unit tests, and integration tests were updated accordingly. Separately removes the unused `TokenDAO.list_by_refresh_token()` method.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13a9d84248a1c9d59daae09e2d1e6a6a83db64bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->