### PR TITLE
external_auth: emit lifecycle events on tenant config changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 26.06
+
+* The following events have been added on tenant-scoped external auth config changes:
+    * `auth_external_auth_added` on `POST /0.1/external/<auth_type>/config`
+    * `auth_external_auth_updated` on `PUT /0.1/external/<auth_type>/config`
+    * `auth_external_auth_deleted` on `DELETE /0.1/external/<auth_type>/config`
+
 ## 26.04
 
 * `POST /0.1/token` (`Wazo-Session-Type: mobile`, `access_type=offline`):

--- a/integration_tests/suite/test_external.py
+++ b/integration_tests/suite/test_external.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import time
@@ -291,6 +291,9 @@ class TestExternalAuthConfigAPI(base.ExternalAuthIntegrationTest):
         )
 
     def test_given_create_config_when_get_config_then_ok(self):
+        headers = {'name': 'auth_external_auth_added'}
+        msg_accumulator = self.bus.accumulator(headers=headers)
+
         self.client.external.create_config(
             auth_type=self.EXTERNAL_AUTH_TYPE, data=self.SECRET
         )
@@ -298,6 +301,26 @@ class TestExternalAuthConfigAPI(base.ExternalAuthIntegrationTest):
         response = self.client.external.get_config(self.EXTERNAL_AUTH_TYPE)
 
         assert_that(response, has_entries(self.SECRET))
+
+        def bus_received_msg():
+            assert_that(
+                msg_accumulator.accumulate(with_headers=True),
+                contains_exactly(
+                    has_entries(
+                        message=has_entries(
+                            data=has_entries(
+                                external_auth_name=self.EXTERNAL_AUTH_TYPE,
+                            )
+                        ),
+                        headers=has_entries(
+                            name='auth_external_auth_added',
+                            tenant_uuid=self.top_tenant_uuid,
+                        ),
+                    )
+                ),
+            )
+
+        until.assert_(bus_received_msg, tries=10, interval=0.25)
 
     def test_given_config_when_create_same_config_then_conflict(self):
         self.client.external.create_config(
@@ -315,6 +338,38 @@ class TestExternalAuthConfigAPI(base.ExternalAuthIntegrationTest):
         base.assert_http_error(
             404, self.client.external.delete_config, self.EXTERNAL_AUTH_TYPE
         )
+
+    def test_given_config_when_delete_config_then_event_emitted(self):
+        self.client.external.create_config(
+            auth_type=self.EXTERNAL_AUTH_TYPE, data=self.SECRET
+        )
+
+        headers = {'name': 'auth_external_auth_deleted'}
+        msg_accumulator = self.bus.accumulator(headers=headers)
+
+        base.assert_no_error(
+            self.client.external.delete_config, self.EXTERNAL_AUTH_TYPE
+        )
+
+        def bus_received_msg():
+            assert_that(
+                msg_accumulator.accumulate(with_headers=True),
+                contains_exactly(
+                    has_entries(
+                        message=has_entries(
+                            data=has_entries(
+                                external_auth_name=self.EXTERNAL_AUTH_TYPE,
+                            )
+                        ),
+                        headers=has_entries(
+                            name='auth_external_auth_deleted',
+                            tenant_uuid=self.top_tenant_uuid,
+                        ),
+                    )
+                ),
+            )
+
+        until.assert_(bus_received_msg, tries=10, interval=0.25)
 
     def test_given_config_when_get_config_from_wrong_tenant_then_not_found(self):
         self.client.external.create_config(
@@ -335,6 +390,9 @@ class TestExternalAuthConfigAPI(base.ExternalAuthIntegrationTest):
         new_secret = dict(self.SECRET)
         new_secret['secret'] = 'secret'
 
+        headers = {'name': 'auth_external_auth_updated'}
+        msg_accumulator = self.bus.accumulator(headers=headers)
+
         base.assert_no_error(
             self.client.external.update_config, self.EXTERNAL_AUTH_TYPE, new_secret
         )
@@ -342,6 +400,26 @@ class TestExternalAuthConfigAPI(base.ExternalAuthIntegrationTest):
         response = self.client.external.get_config(self.EXTERNAL_AUTH_TYPE)
 
         assert_that(response, has_entries(new_secret))
+
+        def bus_received_msg():
+            assert_that(
+                msg_accumulator.accumulate(with_headers=True),
+                contains_exactly(
+                    has_entries(
+                        message=has_entries(
+                            data=has_entries(
+                                external_auth_name=self.EXTERNAL_AUTH_TYPE,
+                            )
+                        ),
+                        headers=has_entries(
+                            name='auth_external_auth_updated',
+                            tenant_uuid=self.top_tenant_uuid,
+                        ),
+                    )
+                ),
+            )
+
+        until.assert_(bus_received_msg, tries=10, interval=0.25)
 
     def test_given_no_config_when_update_config_then_not_found(self):
         base.assert_http_error(

--- a/wazo_auth/services/external_auth.py
+++ b/wazo_auth/services/external_auth.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
@@ -9,6 +9,9 @@ from functools import partial
 import marshmallow
 import websocket
 from wazo_bus.resources.auth.events import (
+    ExternalAuthAddedEvent,
+    ExternalAuthDeletedEvent,
+    ExternalAuthUpdatedEvent,
     UserExternalAuthAddedEvent,
     UserExternalAuthAuthorizedEvent,
     UserExternalAuthDeletedEvent,
@@ -113,7 +116,10 @@ class ExternalAuthService(BaseService):
         return result
 
     def create_config(self, auth_type, data, tenant_uuid):
-        return self._dao.external_auth.create_config(auth_type, data, tenant_uuid)
+        result = self._dao.external_auth.create_config(auth_type, data, tenant_uuid)
+        event = ExternalAuthAddedEvent(auth_type, tenant_uuid)
+        self._bus_publisher.publish(event)
+        return result
 
     def delete(self, user_uuid, auth_type):
         self._dao.external_auth.delete(user_uuid, auth_type)
@@ -123,6 +129,8 @@ class ExternalAuthService(BaseService):
 
     def delete_config(self, auth_type, tenant_uuid):
         self._dao.external_auth.delete_config(auth_type, tenant_uuid)
+        event = ExternalAuthDeletedEvent(auth_type, tenant_uuid)
+        self._bus_publisher.publish(event)
 
     def get(self, user_uuid, auth_type):
         return self._dao.external_auth.get(user_uuid, auth_type)
@@ -197,4 +205,7 @@ class ExternalAuthService(BaseService):
             return self.create(user_uuid, auth_type, data)
 
     def update_config(self, auth_type, data, tenant_uuid):
-        return self._dao.external_auth.update_config(auth_type, data, tenant_uuid)
+        result = self._dao.external_auth.update_config(auth_type, data, tenant_uuid)
+        event = ExternalAuthUpdatedEvent(auth_type, tenant_uuid)
+        self._bus_publisher.publish(event)
+        return result

--- a/wazo_auth/tests/test_services.py
+++ b/wazo_auth/tests/test_services.py
@@ -14,7 +14,13 @@ from hamcrest import (
     not_,
     raises,
 )
-from wazo_bus.resources.auth.events import RefreshTokenDeletedEvent, SessionDeletedEvent
+from wazo_bus.resources.auth.events import (
+    ExternalAuthAddedEvent,
+    ExternalAuthDeletedEvent,
+    ExternalAuthUpdatedEvent,
+    RefreshTokenDeletedEvent,
+    SessionDeletedEvent,
+)
 from xivo.mallow import fields
 
 from wazo_auth.config import _DEFAULT_CONFIG
@@ -94,7 +100,40 @@ class TestExternalAuthService(BaseServiceTestCase):
 
     def setUp(self):
         super().setUp()
-        self.service = services.ExternalAuthService(self.dao, _DEFAULT_CONFIG)
+        self.bus_publisher = Mock(BusPublisher)
+        self.service = services.ExternalAuthService(
+            self.dao, _DEFAULT_CONFIG, self.bus_publisher
+        )
+
+    def test_create_config_publishes_added_event(self):
+        self.service.create_config(s.auth_type, s.data, s.tenant_uuid)
+
+        self.external_auth_dao.create_config.assert_called_once_with(
+            s.auth_type, s.data, s.tenant_uuid
+        )
+        self.bus_publisher.publish.assert_called_once_with(
+            ExternalAuthAddedEvent(s.auth_type, s.tenant_uuid)
+        )
+
+    def test_update_config_publishes_updated_event(self):
+        self.service.update_config(s.auth_type, s.data, s.tenant_uuid)
+
+        self.external_auth_dao.update_config.assert_called_once_with(
+            s.auth_type, s.data, s.tenant_uuid
+        )
+        self.bus_publisher.publish.assert_called_once_with(
+            ExternalAuthUpdatedEvent(s.auth_type, s.tenant_uuid)
+        )
+
+    def test_delete_config_publishes_deleted_event(self):
+        self.service.delete_config(s.auth_type, s.tenant_uuid)
+
+        self.external_auth_dao.delete_config.assert_called_once_with(
+            s.auth_type, s.tenant_uuid
+        )
+        self.bus_publisher.publish.assert_called_once_with(
+            ExternalAuthDeletedEvent(s.auth_type, s.tenant_uuid)
+        )
 
     def test_list_external_auth(self):
         # No safe model registered for any auth type


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/wazo-bus/pull/145

## Summary

- Publish `ExternalAuthAddedEvent`, `ExternalAuthUpdatedEvent` and `ExternalAuthDeletedEvent` from `ExternalAuthService.create_config / update_config / delete_config`, mirroring the existing per-user external_auth event flow
- Add unit-test coverage in `wazo_auth/tests/test_services.py::TestExternalAuthService` and bus-assertion coverage in `integration_tests/suite/test_external.py::TestExternalAuthConfigAPI`
- CHANGELOG entry under 26.06

## Test plan
- [ ] `pytest wazo_auth/tests/test_services.py::TestExternalAuthService` passes
- [ ] Integration suite `TestExternalAuthConfigAPI` create/update/delete tests observe the expected bus events
- [ ] pre-commit (flake8, black, isort, mypy, copyright) clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new bus events on tenant-scoped external auth config create/update/delete, which can affect downstream event consumers and requires correct tenant scoping. Core auth logic is otherwise unchanged and covered by new unit/integration tests.
> 
> **Overview**
> Tenant-scoped external auth configuration changes now emit lifecycle events: `auth_external_auth_added`, `auth_external_auth_updated`, and `auth_external_auth_deleted` from `ExternalAuthService.create_config`/`update_config`/`delete_config`.
> 
> Tests are extended to assert these events are published (unit tests) and observable via the integration suite bus accumulator on the corresponding `POST`/`PUT`/`DELETE /0.1/external/<auth_type>/config` APIs, and the change is documented in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4dcd3d6c56f61519f7092f45ff918a022b81f72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->