### PR TITLE
idp: use user_uuid for login from refresh token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 26.07
+
+* `POST /0.1/token` (`refresh_token` grant): the login is now resolved live from the refresh token's `user_uuid` (current username, falling back to main confirmed email) instead of the value frozen at creation. Refresh tokens keep working after a username or confirmed-email change; the stored `login` is no longer used for authentication.
+
 ## 26.06
 
 * The following events have been added on tenant-scoped external auth config changes:

--- a/integration_tests/suite/test_token.py
+++ b/integration_tests/suite/test_token.py
@@ -194,6 +194,72 @@ class TestTokens(base.APIIntegrationTest):
         )
         assert_that(result, not_(has_key('refresh_token')))
 
+    @fixtures.http.user(username='to-rename', password='secret')
+    def test_refresh_token_login_works_after_username_change(self, user):
+        client_id = 'rt-username-change'
+        user_client = self.make_auth_client('to-rename', 'secret')
+
+        created = user_client.token.new(
+            'wazo_user', access_type='offline', client_id=client_id
+        )
+        refresh_token = created['refresh_token']
+        assert_that(refresh_token, not_(None))
+
+        self.client.users.edit(user['uuid'], username='renamed')
+
+        refreshed = user_client.token.new(
+            refresh_token=refresh_token, client_id=client_id
+        )
+        assert_that(refreshed, has_entries(metadata=has_entries(uuid=user['uuid'])))
+
+    @fixtures.http.user(
+        username=None, email_address='old@example.com', password='secret'
+    )
+    def test_refresh_token_login_works_after_email_change(self, user):
+        client_id = 'rt-email-change'
+        user_client = self.make_auth_client('old@example.com', 'secret')
+
+        created = user_client.token.new(
+            'wazo_user', access_type='offline', client_id=client_id
+        )
+        refresh_token = created['refresh_token']
+        assert_that(refresh_token, not_(None))
+
+        # The email the refresh token was created with is replaced by a new
+        # confirmed one (admin endpoint, so it is immediately a valid login)
+        new_email = {'address': 'new@example.com', 'main': True, 'confirmed': True}
+        self.client.admin.update_user_emails(user['uuid'], [new_email])
+
+        # The refresh token must still resolve to the user despite the email change
+        refreshed = user_client.token.new(
+            refresh_token=refresh_token, client_id=client_id
+        )
+        assert_that(refreshed, has_entries(metadata=has_entries(uuid=user['uuid'])))
+
+    @fixtures.http.user(
+        username=None, email_address='temp@example.com', password='secret'
+    )
+    def test_refresh_token_login_fails_cleanly_when_user_has_no_valid_login(self, user):
+        client_id = 'rt-no-login'
+        user_client = self.make_auth_client('temp@example.com', 'secret')
+        created = user_client.token.new(
+            'wazo_user', access_type='offline', client_id=client_id
+        )
+        refresh_token = created['refresh_token']
+
+        # Leave the user with no valid login: no username, main email unconfirmed
+        self.client.admin.update_user_emails(
+            user['uuid'],
+            [{'address': 'temp@example.com', 'main': True, 'confirmed': False}],
+        )
+
+        assert_http_error(
+            401,
+            user_client.token.new,
+            refresh_token=refresh_token,
+            client_id=client_id,
+        )
+
     @fixtures.http.user(username='foo')
     def test_refresh_token_created_event(self, user):
         msg_accumulator = self.bus.accumulator(

--- a/wazo_auth/database/queries/refresh_token.py
+++ b/wazo_auth/database/queries/refresh_token.py
@@ -84,6 +84,7 @@ class RefreshTokenDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
             return {
                 'backend_name': refresh_token.backend,
                 'login': refresh_token.login,
+                'user_uuid': refresh_token.user_uuid,
                 'metadata': refresh_token.metadata_,
             }
 

--- a/wazo_auth/plugins/idp/refresh_token.py
+++ b/wazo_auth/plugins/idp/refresh_token.py
@@ -1,4 +1,4 @@
-# Copyright 2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2025-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -116,7 +116,10 @@ class RefreshTokenIDP(BaseIDP):
             client_id,
         )
 
-        login = refresh_token_data['login']
+        # The login stored on the refresh token is frozen at creation time and
+        # goes stale when the user's username or emails change. Resolve a fresh,
+        # currently-valid login from the (stable) user_uuid instead.
+        login = self._user_service.get_login_by_uuid(refresh_token_data['user_uuid'])
         args['login'] = login
 
         # persistent_metadata is consumed by TokenService.new_token

--- a/wazo_auth/plugins/idp/refresh_token.py
+++ b/wazo_auth/plugins/idp/refresh_token.py
@@ -116,9 +116,6 @@ class RefreshTokenIDP(BaseIDP):
             client_id,
         )
 
-        # The login stored on the refresh token is frozen at creation time and
-        # goes stale when the user's username or emails change. Resolve a fresh,
-        # currently-valid login from the (stable) user_uuid instead.
         login = self._user_service.get_login_by_uuid(refresh_token_data['user_uuid'])
         args['login'] = login
 

--- a/wazo_auth/plugins/idp/tests/test_refresh_token.py
+++ b/wazo_auth/plugins/idp/tests/test_refresh_token.py
@@ -1,4 +1,4 @@
-# Copyright 2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2025-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
@@ -75,10 +75,13 @@ def test_verify_auth_ok(refresh_token_idp: RefreshTokenIDP):
     user.uuid = 'user_uuid'
     user.authentication_method = 'native'
     refresh_token_idp._user_service.get_user_by_login.return_value = user
+    # the current login is resolved live from the token's user_uuid
+    refresh_token_idp._user_service.get_login_by_uuid.return_value = s.login
 
-    # assume refresh token exists and is valid
+    # assume refresh token exists and is valid; its stored login is ignored
     refresh_token_idp._token_service.get_refresh_token_info.return_value = {
-        'login': s.login,
+        'login': s.stale_login,
+        'user_uuid': 'user_uuid',
         'backend': 'native',
         'metadata': {'foo': 'bar'},
     }
@@ -86,6 +89,9 @@ def test_verify_auth_ok(refresh_token_idp: RefreshTokenIDP):
     backend, login = refresh_token_idp.verify_auth(args)
     assert backend
     assert login == s.login
+    refresh_token_idp._user_service.get_login_by_uuid.assert_called_once_with(
+        'user_uuid'
+    )
     assert args['persistent_metadata'] == {'foo': 'bar'}
 
 
@@ -97,6 +103,13 @@ def test_verify_auth_bad_auth_method(refresh_token_idp: RefreshTokenIDP):
     user.uuid = 'user_uuid'
     user.authentication_method = 'something'
     refresh_token_idp._user_service.get_user_by_login.return_value = user
+    refresh_token_idp._user_service.get_login_by_uuid.return_value = s.login
+
+    refresh_token_idp._token_service.get_refresh_token_info.return_value = {
+        'login': s.stale_login,
+        'user_uuid': 'user_uuid',
+        'metadata': {'foo': 'bar'},
+    }
 
     with pytest.raises(UnauthorizedAuthenticationMethod):
         refresh_token_idp.verify_auth(args)
@@ -122,9 +135,11 @@ def test_verify_auth_idp_auth_method(refresh_token_idp: RefreshTokenIDP):
     user.uuid = 'user_uuid'
     user.authentication_method = 'custom'
     refresh_token_idp._user_service.get_user_by_login.return_value = user
+    refresh_token_idp._user_service.get_login_by_uuid.return_value = s.login
 
     refresh_token_idp._token_service.get_refresh_token_info.return_value = {
-        'login': s.login,
+        'login': s.stale_login,
+        'user_uuid': 'user_uuid',
         'metadata': {'foo': 'bar'},
     }
 

--- a/wazo_auth/services/user.py
+++ b/wazo_auth/services/user.py
@@ -49,13 +49,7 @@ class UserService(BaseService):
 
     def change_password(self, user_uuid, old_password, new_password, reset=False):
         user = self.get_user(user_uuid)
-        login = user['username']
-        if not login:
-            login = self._find_main_email(user)
-
-        if not login:
-            logger.warning('User %s does not have login (username or email)', user_uuid)
-            raise exceptions.AuthenticationFailedException()
+        login = self._resolve_login(user)
 
         if not self.verify_password(login, old_password, reset):
             raise exceptions.AuthenticationFailedException()
@@ -72,6 +66,18 @@ class UserService(BaseService):
         for email in user['emails']:
             if email['main'] and email['confirmed']:
                 return email['address']
+
+    def _resolve_login(self, user):
+        login = user['username'] or self._find_main_email(user)
+        if not login:
+            logger.warning(
+                'User %s does not have login (username or email)', user['uuid']
+            )
+            raise exceptions.AuthenticationFailedException()
+        return login
+
+    def get_login_by_uuid(self, user_uuid):
+        return self._resolve_login(self.get_user(user_uuid))
 
     def delete_password(self, **kwargs):
         search_params = {k: v for k, v in kwargs.items() if v}


### PR DESCRIPTION
Why: allows to change username / email and still be able to login

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication for the refresh_token grant in wazo-auth; behavior is well-tested but any mistake could break mobile/offline sessions or accept stale identities.
> 
> **Overview**
> **Refresh token grants** on `POST /0.1/token` now bind the user via `user_uuid` and resolve the login at refresh time (`username`, else main confirmed email) instead of the `login` string stored when the token was issued. Offline clients keep working after username or primary-email changes; if the user ends up with no valid login, refresh returns **401**.
> 
> `RefreshTokenDAO.get` returns `user_uuid`; `UserService` adds `get_login_by_uuid` / `_resolve_login` (also used by `change_password`). Integration tests cover rename, email change, and the no-login failure path; changelog documents 26.07 behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95fca7b51ddee34828e3afb4474b2804174e4af9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->