### PR TITLE
ITEM-404 integration_tests: use shared wazo_test_helpers.pytest_asset plugin

### DIFF
--- a/integration_tests/suite/conftest.py
+++ b/integration_tests/suite/conftest.py
@@ -1,72 +1,115 @@
 # Copyright 2021-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import logging
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+
 import pytest
+from wazo_test_helpers.asset_launching_test_case import AssetLaunchingTestCase
 
 from .helpers import base as asset
 
+logger = logging.getLogger(__name__)
+
+_teardowns: dict[str, Callable[[], None]] = {}
+_teardown_failures: list[tuple[str, BaseException]] = []
+
 
 def pytest_collection_modifyitems(session, config, items):
-    # item == test method
-    # item.parent == test class
-    # item.parent.own_markers == pytest markers of the test class
-    # item.parent.own_markers[0].args[0] == name of the asset
-    # It also remove the run-order pytest feature (--ff, --nf)
-    items.sort(key=lambda item: item.parent.own_markers[0].args[0])
+    # Group tests by their asset so each asset is set up/torn down once, in a
+    # contiguous run (this also removes the run-order pytest feature --ff/--nf).
+    items.sort(key=lambda item: _marker_of(item) or '')
 
 
-@pytest.fixture(scope='package')
-def base():
-    asset.APIAssetLaunchingTestCase.setUpClass()
+def _marker_of(item) -> str | None:
+    # The asset name is the argument of the `use_asset` (usefixtures) marker.
+    # Find it explicitly rather than assuming it is the first/only class marker.
+    parent = getattr(item, 'parent', None)
+    for marker in getattr(parent, 'own_markers', []):
+        if marker.name == 'usefixtures' and marker.args:
+            return marker.args[0]
+    return None
+
+
+def _teardown(marker: str) -> None:
+    teardown = _teardowns.get(marker)
+    if teardown is not None:
+        teardown()
+        _teardowns.pop(marker, None)
+
+
+@contextmanager
+def managed_asset(request, asset_class: type[AssetLaunchingTestCase]) -> Iterator[None]:
+    marker = request.fixturename
+    asset_class.setUpClass()
+    _teardowns[marker] = asset_class.tearDownClass
     try:
         yield
     finally:
-        asset.APIAssetLaunchingTestCase.tearDownClass()
+        _teardown(marker)
 
 
-@pytest.fixture(scope='package')
-def saml():
-    asset.SAMLAssetLaunchingTestCase.setUpClass()
-    try:
+@pytest.hookimpl(trylast=True)
+def pytest_runtest_teardown(item, nextitem) -> None:
+    # Eagerly tear down the active asset at marker-group boundaries; the
+    # session-scoped fixture's finally still handles the very last asset.
+    # Swallow errors here so a teardown failure can't abort the next test's
+    # setup; the fixture-finally path lets exceptions propagate so they
+    # surface in pytest's error summary.
+    if nextitem is None:
+        return
+    current = _marker_of(item)
+    upcoming = _marker_of(nextitem)
+    if current is not None and current != upcoming:
+        try:
+            _teardown(current)
+        except Exception as exc:
+            logger.exception('Failed to tear down asset for marker %r', current)
+            _teardown_failures.append((current, exc))
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config) -> None:
+    for marker, exc in _teardown_failures:
+        terminalreporter.write_sep(
+            '!', f'Asset teardown failed for marker {marker!r}: {exc}'
+        )
+
+
+@pytest.fixture(scope='session')
+def base(request):
+    with managed_asset(request, asset.APIAssetLaunchingTestCase):
         yield
-    finally:
-        asset.SAMLAssetLaunchingTestCase.tearDownClass()
 
 
-@pytest.fixture(scope='package')
-def database():
-    asset.DBAssetLaunchingTestCase.setUpClass()
-    try:
+@pytest.fixture(scope='session')
+def saml(request):
+    with managed_asset(request, asset.SAMLAssetLaunchingTestCase):
         yield
-    finally:
-        asset.DBAssetLaunchingTestCase.tearDownClass()
 
 
-@pytest.fixture(scope='package')
-def external_auth():
-    asset.ExternalAuthAssetLaunchingTestCase.setUpClass()
-    try:
+@pytest.fixture(scope='session')
+def database(request):
+    with managed_asset(request, asset.DBAssetLaunchingTestCase):
         yield
-    finally:
-        asset.ExternalAuthAssetLaunchingTestCase.tearDownClass()
 
 
-@pytest.fixture(scope='package')
-def metadata():
-    asset.MetadataAssetLaunchingTestCase.setUpClass()
-    try:
+@pytest.fixture(scope='session')
+def external_auth(request):
+    with managed_asset(request, asset.ExternalAuthAssetLaunchingTestCase):
         yield
-    finally:
-        asset.MetadataAssetLaunchingTestCase.tearDownClass()
 
 
-@pytest.fixture(scope='package')
-def bootstrap():
-    asset.BootstrapAssetLaunchingTestCase.setUpClass()
-    try:
+@pytest.fixture(scope='session')
+def metadata(request):
+    with managed_asset(request, asset.MetadataAssetLaunchingTestCase):
         yield
-    finally:
-        asset.BootstrapAssetLaunchingTestCase.tearDownClass()
+
+
+@pytest.fixture(scope='session')
+def bootstrap(request):
+    with managed_asset(request, asset.BootstrapAssetLaunchingTestCase):
+        yield
 
 
 @pytest.fixture(autouse=True, scope='function')

--- a/integration_tests/suite/conftest.py
+++ b/integration_tests/suite/conftest.py
@@ -1,123 +1,28 @@
 # Copyright 2021-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import logging
-from collections.abc import Callable, Iterator
-from contextlib import contextmanager
-
 import pytest
-from wazo_test_helpers.asset_launching_test_case import AssetLaunchingTestCase
+from wazo_test_helpers.pytest_asset import (
+    asset_fixture,
+    enable_mark_logs_fixture,
+    register,
+)
 
 from .helpers import base as asset
 
-logger = logging.getLogger(__name__)
 
-_teardowns: dict[str, Callable[[], None]] = {}
-_teardown_failures: list[tuple[str, BaseException]] = []
-
-
-def pytest_collection_modifyitems(session, config, items):
-    # Group tests by their asset so each asset is set up/torn down once, in a
-    # contiguous run (this also removes the run-order pytest feature --ff/--nf).
-    items.sort(key=lambda item: _marker_of(item) or '')
+def pytest_configure(config):
+    register(config)
 
 
-def _marker_of(item) -> str | None:
-    # The asset name is the argument of the `use_asset` (usefixtures) marker.
-    # Find it explicitly rather than assuming it is the first/only class marker.
-    parent = getattr(item, 'parent', None)
-    for marker in getattr(parent, 'own_markers', []):
-        if marker.name == 'usefixtures' and marker.args:
-            return marker.args[0]
-    return None
+base = asset_fixture(asset.APIAssetLaunchingTestCase)
+saml = asset_fixture(asset.SAMLAssetLaunchingTestCase)
+database = asset_fixture(asset.DBAssetLaunchingTestCase)
+external_auth = asset_fixture(asset.ExternalAuthAssetLaunchingTestCase)
+metadata = asset_fixture(asset.MetadataAssetLaunchingTestCase)
+bootstrap = asset_fixture(asset.BootstrapAssetLaunchingTestCase)
 
-
-def _teardown(marker: str) -> None:
-    teardown = _teardowns.get(marker)
-    if teardown is not None:
-        teardown()
-        _teardowns.pop(marker, None)
-
-
-@contextmanager
-def managed_asset(request, asset_class: type[AssetLaunchingTestCase]) -> Iterator[None]:
-    marker = request.fixturename
-    asset_class.setUpClass()
-    _teardowns[marker] = asset_class.tearDownClass
-    try:
-        yield
-    finally:
-        _teardown(marker)
-
-
-@pytest.hookimpl(trylast=True)
-def pytest_runtest_teardown(item, nextitem) -> None:
-    # Eagerly tear down the active asset at marker-group boundaries; the
-    # session-scoped fixture's finally still handles the very last asset.
-    # Swallow errors here so a teardown failure can't abort the next test's
-    # setup; the fixture-finally path lets exceptions propagate so they
-    # surface in pytest's error summary.
-    if nextitem is None:
-        return
-    current = _marker_of(item)
-    upcoming = _marker_of(nextitem)
-    if current is not None and current != upcoming:
-        try:
-            _teardown(current)
-        except Exception as exc:
-            logger.exception('Failed to tear down asset for marker %r', current)
-            _teardown_failures.append((current, exc))
-
-
-def pytest_terminal_summary(terminalreporter, exitstatus, config) -> None:
-    for marker, exc in _teardown_failures:
-        terminalreporter.write_sep(
-            '!', f'Asset teardown failed for marker {marker!r}: {exc}'
-        )
-
-
-@pytest.fixture(scope='session')
-def base(request):
-    with managed_asset(request, asset.APIAssetLaunchingTestCase):
-        yield
-
-
-@pytest.fixture(scope='session')
-def saml(request):
-    with managed_asset(request, asset.SAMLAssetLaunchingTestCase):
-        yield
-
-
-@pytest.fixture(scope='session')
-def database(request):
-    with managed_asset(request, asset.DBAssetLaunchingTestCase):
-        yield
-
-
-@pytest.fixture(scope='session')
-def external_auth(request):
-    with managed_asset(request, asset.ExternalAuthAssetLaunchingTestCase):
-        yield
-
-
-@pytest.fixture(scope='session')
-def metadata(request):
-    with managed_asset(request, asset.MetadataAssetLaunchingTestCase):
-        yield
-
-
-@pytest.fixture(scope='session')
-def bootstrap(request):
-    with managed_asset(request, asset.BootstrapAssetLaunchingTestCase):
-        yield
-
-
-@pytest.fixture(autouse=True, scope='function')
-def mark_logs(request):
-    test_name = f'{request.cls.__name__}.{request.function.__name__}'
-    request.cls.asset_cls.mark_logs_test_start(test_name)
-    yield
-    request.cls.asset_cls.mark_logs_test_end(test_name)
+mark_logs = enable_mark_logs_fixture()
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/wazo-test-helpers/pull/127

## What

Replaces the per-suite asset lifecycle boilerplate in the integration suite
(collection ordering, eager marker-boundary teardown, teardown-failure
reporting, `mark_logs`) with the shared `wazo_test_helpers.pytest_asset` plugin
introduced in wazo-platform/wazo-test-helpers#127.

The conftest now only declares its assets via `asset_fixture()`, opts into log
markers via `enable_mark_logs_fixture()`, and calls `register()` from its own
`pytest_configure` to activate the hooks.