### PR TITLE
[ITEM-407] feat(users): emit UserDeletedEvent on user deletion

### DIFF
--- a/integration_tests/suite/test_users.py
+++ b/integration_tests/suite/test_users.py
@@ -45,6 +45,40 @@ class TestUsers(base.APIIntegrationTest):
         assert_no_error(self.client.users.delete, alice['uuid'])
         assert_http_error(404, self.client.users.delete, alice['uuid'])
 
+    @fixtures.http.user(username='to_delete', password='secret')
+    def test_delete_event(self, user):
+        user_client = self.make_auth_client('to_delete', 'secret')
+        token = user_client.token.new('wazo_user', expiration=60)['token']
+
+        headers = {'name': 'auth_user_deleted'}
+        msg_accumulator = self.bus.accumulator(headers=headers)
+
+        self.client.users.delete(user['uuid'])
+
+        def bus_received_msg():
+            assert_that(
+                msg_accumulator.accumulate(with_headers=True),
+                has_item(
+                    has_entries(
+                        message=has_entries(
+                            data={
+                                'uuid': user['uuid'],
+                                'tenant_uuid': user['tenant_uuid'],
+                            }
+                        ),
+                        headers=has_entries(
+                            {
+                                'tenant_uuid': user['tenant_uuid'],
+                                f'user_uuid:{user["uuid"]}': True,
+                            }
+                        ),
+                    )
+                ),
+            )
+
+        until.assert_(bus_received_msg, tries=10, interval=0.25)
+        assert not self.client.token.is_valid(token)
+
     @fixtures.http.user(username='foobar', email_address='foobar@example.com')
     @fixtures.http.user(username='foobaz', email_address='foobaz@example.com')
     def test_password_reset_does_not_disable_old_password(self, foobar, foobaz):

--- a/integration_tests/suite/test_users.py
+++ b/integration_tests/suite/test_users.py
@@ -45,7 +45,7 @@ class TestUsers(base.APIIntegrationTest):
         assert_no_error(self.client.users.delete, alice['uuid'])
         assert_http_error(404, self.client.users.delete, alice['uuid'])
 
-    @fixtures.http.user(username='to_delete', password='secret')
+    @fixtures.http.user(username='to_delete', password='secret')  # NOSONAR
     def test_delete_event(self, user):
         user_client = self.make_auth_client('to_delete', 'secret')
         token = user_client.token.new('wazo_user', expiration=60)['token']

--- a/wazo_auth/services/user.py
+++ b/wazo_auth/services/user.py
@@ -6,7 +6,7 @@ import hashlib
 import logging
 import os
 
-from wazo_bus.resources.auth.events import SessionDeletedEvent
+from wazo_bus.resources.auth.events import SessionDeletedEvent, UserDeletedEvent
 
 from wazo_auth import exceptions
 from wazo_auth.services.helpers import BaseService
@@ -128,7 +128,22 @@ class UserService(BaseService):
 
     def delete_user(self, scoping_tenant_uuid, user_uuid):
         self.assert_user_in_subtenant(scoping_tenant_uuid, user_uuid)
+        user = self.get_user(user_uuid)
+        sessions = self._dao.session.delete_by_user(user_uuid)
         self._dao.user.delete(user_uuid)
+        self._publish_session_deleted_events(user, sessions)
+        self._publish_user_deleted_event(user)
+
+    def _publish_user_deleted_event(self, user):
+        if self._bus_publisher is None:
+            logger.warning('Publisher is missing, unable to publish user deleted event')
+            return
+
+        event = UserDeletedEvent(
+            tenant_uuid=user['tenant_uuid'],
+            user_uuid=user['uuid'],
+        )
+        self._bus_publisher.publish(event)
 
     def get_acl(self, user_uuid):
         users = self._dao.user.list_(uuid=user_uuid, limit=1)

--- a/wazo_auth/tests/test_services.py
+++ b/wazo_auth/tests/test_services.py
@@ -20,6 +20,7 @@ from wazo_bus.resources.auth.events import (
     ExternalAuthUpdatedEvent,
     RefreshTokenDeletedEvent,
     SessionDeletedEvent,
+    UserDeletedEvent,
 )
 from xivo.mallow import fields
 
@@ -373,6 +374,27 @@ class TestUserService(BaseServiceTestCase):
             user_uuid, salt=None, hash_=None
         )
         assert_that(result, has_entries(uuid=user_uuid))
+
+    def test_delete_user(self):
+        tenant_uuid = 'tenant-uuid'
+        user_uuid = 'user-uuid'
+        user = {'uuid': user_uuid, 'tenant_uuid': tenant_uuid}
+        self.user_dao.list_.return_value = [user]
+        self.user_dao.exists.return_value = True
+        self.tenant_dao.list_visible_tenants.return_value = []
+        self.session_dao.delete_by_user.return_value = [{'uuid': 'session-1'}]
+
+        self.service.delete_user('scoping-tenant', user_uuid)
+
+        self.session_dao.delete_by_user.assert_called_once_with(user_uuid)
+        self.user_dao.delete.assert_called_once_with(user_uuid)
+        assert_that(
+            self.bus_publisher.publish.call_args_list,
+            contains_exactly(
+                ((SessionDeletedEvent('session-1', tenant_uuid, user_uuid),),),
+                ((UserDeletedEvent(tenant_uuid=tenant_uuid, user_uuid=user_uuid),),),
+            ),
+        )
 
     def test_remove_policy(self):
         def when(nb_deleted, user_exists=True, policy_exists=True):


### PR DESCRIPTION
## Summary of the changes

- `UserService.delete_user` now publishes a new `auth_user_deleted` event when a user is deleted
- It also deletes the user's active sessions (emitting `auth_session_deleted` per session, same as the disable-user flow), which invalidates their tokens
- Added unit + integration tests

The event is user-scoped (`UserEvent`), so wazo-websocketd delivers it over the websocket **only** to the deleted user's own session (via the `user_uuid:{uuid}` header). This lets the mobile/web app know the current session user was deleted and log out gracefully.

> [!IMPORTANT]
> Depends on wazo-bus PR https://github.com/wazo-platform/wazo-bus/pull/147 which adds `UserDeletedEvent`. Merge that first — these tests import it.
> The end-user ACL grant is in wazo-auth-keys PR https://github.com/wazo-platform/wazo-auth-keys/pull/102.

## How to test

- Unit: `tox -e py311` (`test_delete_user` in `wazo_auth/tests/test_services.py`)
- Integration: `test_delete_event` in `integration_tests/suite/test_users.py`
- Manually: open a websocket as a user, then `DELETE /users/{uuid}` as admin → the client receives an `auth_user_deleted` event and its token becomes invalid

Depends-On: https://github.com/wazo-platform/wazo-bus/pull/147
Depends-On: https://github.com/wazo-platform/wazo-auth-keys/pull/102