### PR TITLE
ITEM-447-dynamic-thread-pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 26.08
 
 * Added `--http-worker` flag to start HTTP-only wazo-auth instance
+* New `rest_api.min_threads` option: threads kept ready at all times.
+  `max_threads` is now a ceiling the pool grows to under load, not a fixed
+  thread count.
 
 ## 26.07
 

--- a/etc/wazo-auth/config.yml
+++ b/etc/wazo-auth/config.yml
@@ -31,8 +31,14 @@ password_reset_email_subject_template: '/var/lib/wazo-auth/templates/password_re
 # REST API server
 rest_api:
 
-  # The maximum number of threads in the webserver thread pool
-  max_threads: 25
+  # Minimum of concurrent threads processing requests. This many threads
+  # (and database connections) are kept ready at all times.
+  min_threads: 25
+
+  # Maximum of concurrent threads processing requests. The number of threads
+  # (and database connections) scales with demand between min_threads and
+  # max_threads.
+  max_threads: 200
 
   listen: 127.0.0.1
   port: 9497

--- a/wazo_auth/config.py
+++ b/wazo_auth/config.py
@@ -88,7 +88,8 @@ _DEFAULT_CONFIG = {
     },
     'backend_policies': {},  # since 21.14: Deprecated
     'rest_api': {
-        'max_threads': 25,
+        'min_threads': 25,
+        'max_threads': 200,
         'num_proxies': 1,
         'listen': '127.0.0.1',
         'port': _DEFAULT_HTTP_PORT,

--- a/wazo_auth/controller.py
+++ b/wazo_auth/controller.py
@@ -96,7 +96,12 @@ def _load_idp_plugins(
 
 class Controller:
     def __init__(self, config):
-        init_db(config['db_uri'], pool_size=config['rest_api']['max_threads'])
+        init_db(
+            config['db_uri'],
+            pool_size=config['rest_api']['min_threads'],
+            max_overflow=config['rest_api']['max_threads']
+            - config['rest_api']['min_threads'],
+        )
         self._config = config
         self._http_worker = config.get('http_worker', False)
         self._stopping_thread = None

--- a/wazo_auth/controller.py
+++ b/wazo_auth/controller.py
@@ -33,6 +33,7 @@ from .service_discovery import self_check
 logger = logging.getLogger(__name__)
 
 MISCONFIGURATION_EXIT_CODE = 78
+DB_POOL_SPARE_CONN = 10
 
 
 def _signal_handler(controller, signum, frame):
@@ -96,11 +97,12 @@ def _load_idp_plugins(
 
 class Controller:
     def __init__(self, config):
+        min_threads = config['rest_api']['min_threads']
+        max_threads = config['rest_api']['max_threads']
         init_db(
             config['db_uri'],
-            pool_size=config['rest_api']['min_threads'],
-            max_overflow=config['rest_api']['max_threads']
-            - config['rest_api']['min_threads'],
+            pool_size=min_threads,
+            max_overflow=max_threads - min_threads + DB_POOL_SPARE_CONN,
         )
         self._config = config
         self._http_worker = config.get('http_worker', False)

--- a/wazo_auth/database/helpers.py
+++ b/wazo_auth/database/helpers.py
@@ -16,8 +16,10 @@ logger = logging.getLogger(__name__)
 Session = scoped_session(sessionmaker())
 
 
-def init_db(db_uri, pool_size=16):
-    engine = create_engine(db_uri, pool_size=pool_size, pool_pre_ping=True)
+def init_db(db_uri, pool_size=16, max_overflow=10):
+    engine = create_engine(
+        db_uri, pool_size=pool_size, max_overflow=max_overflow, pool_pre_ping=True
+    )
     Session.configure(bind=engine)
 
 

--- a/wazo_auth/http_server.py
+++ b/wazo_auth/http_server.py
@@ -27,7 +27,7 @@ app = Flask('wazo-auth')
 api = Api(app, prefix=f'/{VERSION}')
 
 
-class ReusePortWSGIServer(wsgi.WSGIServer):
+class ReusePortWSGIServer(wsgi.DynamicWSGIServer):
     @staticmethod
     def prepare_socket(
         bind_addr: Any,
@@ -107,12 +107,13 @@ class CoreRestApi:
         server_class = (
             ReusePortWSGIServer
             if self.config.get('reuse_port', False)
-            else wsgi.WSGIServer
+            else wsgi.DynamicWSGIServer
         )
         self.server = server_class(
             bind_addr=bind_addr,
             wsgi_app=wsgi_app,
-            numthreads=self.config['max_threads'],
+            numthreads=self.config['min_threads'],
+            max=self.config['max_threads'],
         )
         if self.config['certificate'] and self.config['private_key']:
             logger.warning(

--- a/wazo_auth/tests/test_http_server.py
+++ b/wazo_auth/tests/test_http_server.py
@@ -29,7 +29,7 @@ def _core_rest_api(reuse_port):
     return CoreRestApi(config, Mock(), Mock())
 
 
-@patch('wazo_auth.http_server.wsgi.WSGIServer')
+@patch('wazo_auth.http_server.wsgi.DynamicWSGIServer')
 @patch('wazo_auth.http_server.ReusePortWSGIServer')
 def test_run_uses_reuse_port_server_when_enabled(mock_reuse_server, mock_plain_server):
     _core_rest_api(reuse_port=True).run()
@@ -38,7 +38,7 @@ def test_run_uses_reuse_port_server_when_enabled(mock_reuse_server, mock_plain_s
     mock_plain_server.assert_not_called()
 
 
-@patch('wazo_auth.http_server.wsgi.WSGIServer')
+@patch('wazo_auth.http_server.wsgi.DynamicWSGIServer')
 @patch('wazo_auth.http_server.ReusePortWSGIServer')
 def test_run_uses_plain_server_when_reuse_port_disabled(
     mock_reuse_server, mock_plain_server


### PR DESCRIPTION

Depends-on: https://github.com/wazo-platform/xivo-lib-python/pull/187
Why: max_threads was a fixed thread count spawned at startup, wasting
idle threads and DB connections on quiet systems. The pool now grows
and shrinks between the new min_threads setting and max_threads, which
becomes a real ceiling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request concurrency and DB connection limits for all API traffic; mis-tuned min/max could exhaust PostgreSQL connections or cap throughput under load.
> 
> **Overview**
> Replaces a **fixed** `rest_api.max_threads` worker count with a **dynamic** pool between new **`min_threads`** (25, always ready) and **`max_threads`** (200, load ceiling), so idle systems keep fewer threads and DB connections while spikes can grow.
> 
> The REST stack switches from **`WSGIServer`** to **`DynamicWSGIServer`** (xivo-lib-python), passing `numthreads=min_threads` and `max=max_threads`; **`ReusePortWSGIServer`** now subclasses **`DynamicWSGIServer`**. **`init_db`** uses `pool_size=min_threads` and **`max_overflow`** sized to `max_threads - min_threads` plus a small spare (`DB_POOL_SPARE_CONN`), with defaults and **`etc/wazo-auth/config.yml`** updated accordingly. Tests mock **`DynamicWSGIServer`** instead of **`WSGIServer`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a655f5a4c81fec357829aa277ba707f64687b171. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->