### PR TITLE
Serve the API on the nginx internal entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
     * New `wazo-auth-worker@.service` template:
       `systemctl enable --now wazo-auth-worker@19497` adds an API-only
       process on port 19497. See `contribs/scaling/README.md`
+    * nginx serves the API on its internal entry point as well, so other
+      services reach wazo-auth through `http://localhost/api/auth`
 * `service_discovery.advertise_port` defaults to `rest_api.port` instead
   of a static 9497; set it explicitly to advertise a different port
 * `--listen-port` now sets the REST API port as documented; it previously

--- a/debian/wazo-auth.dirs
+++ b/debian/wazo-auth.dirs
@@ -1,3 +1,4 @@
+etc/nginx/locations/http-enabled
 etc/nginx/locations/https-enabled
 etc/rsyslog.d
 etc/wazo-auth/conf.d

--- a/debian/wazo-auth.postinst
+++ b/debian/wazo-auth.postinst
@@ -36,6 +36,13 @@ case "$1" in
                     /etc/nginx/locations/https-enabled/$DAEMONNAME
         fi
 
+        if [[ -z "${previous_version}" ]] || dpkg --compare-versions "${previous_version}" lt '26.09'; then
+            ln -sf /etc/nginx/locations/http-available/$DAEMONNAME \
+                    /etc/nginx/locations/http-enabled/$DAEMONNAME
+            # the symlink is not shipped by dpkg: ask for the nginx reload
+            dpkg-trigger --no-await /etc/nginx/locations/http-enabled || true
+        fi
+
         if [ ! -e "${SAML_DIR}" ]; then
             mkdir -p "${SAML_DIR}"
             chown $USER:$GROUP "$SAML_DIR"

--- a/etc/nginx/locations/http-available/wazo-auth
+++ b/etc/nginx/locations/http-available/wazo-auth
@@ -1,0 +1,6 @@
+# Unlike the https location, the unauthenticated endpoints are not split out to
+# be rate limited: every internal client shares 127.0.0.1.
+location ^~ /api/auth/ {
+    proxy_pass http://wazo-auth/;
+    include /etc/nginx/wazo-auth-shared.conf;
+}


### PR DESCRIPTION
Serves the wazo-auth API on the nginx internal entry point added by
wazo-platform/wazo-nginx#23, so other services can reach it through
`http://localhost/api/auth` and be load balanced over the `wazo-auth` upstream.

Based on `role-based-controller` (#448), since the upstream block lives there.

Notes for review:

* The internal location is a single bare `proxy_pass`, unlike the https one: the
  `/0.1/backends`, `/0.1/status` and `/0.1/saml` split exists only to attach
  `wazo-no-auth-shared.conf` rate limiting per client IP, which cannot work
  internally where every client is 127.0.0.1.
* The symlink is created on upgrade as well, not only on new installations:
  other services send their requests to that entry point, they do not choose to
  use it. `dpkg-trigger` asks wazo-nginx for the nginx reload, because a symlink
  created by postinst is not shipped by dpkg and fires no trigger on its own.
* No `keepalive` / `proxy_http_version`: connection pooling is orthogonal to
  routing internal traffic and applies to the https path equally, since the
  upstream is shared. Keeping nginx's defaults also reproduces today's
  connection behaviour, since the clients already send `Connection: close`.
  Left for its own ticket.
* Second commit only renumbers the pending changelog section to 26.09 (26.08
  ships without this branch) and can be dropped if #448 renumbers it itself.

Verified in a container running wazo-nginx's site file together with these
location files against a stub backend on 9497:
`http://localhost/api/auth/0.1/status` -> 200 with the backend seeing
`/0.1/status`, external https unchanged, off-box http still 301, token masked in
`wazo-internal.access.log`. Unit tests pass; postinst passes `bash -n`.

Ticket: TASK-504

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how internal services reach authentication (routing/load balancing path), but does not alter wazo-auth application logic; misconfiguration or a missed nginx reload could break inter-service auth calls until fixed.
> 
> **Overview**
> Adds **internal nginx routing** so platform services can call wazo-auth at `http://localhost/api/auth`, using the shared `wazo-auth` upstream (including scaled workers) instead of hitting a single backend port directly.
> 
> The new `http-available` location is a single `^~ /api/auth/` proxy (no per-endpoint split used on HTTPS for unauthenticated rate limiting, since internal clients all appear as `127.0.0.1`). **Packaging** creates `etc/nginx/locations/http-enabled`, symlinks the location on fresh installs and on upgrades from before **26.09**, and fires `dpkg-trigger` so nginx reloads after the postinst-created symlink. **CHANGELOG** notes the internal entry point under the 26.09 scaling work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3523b3b92f7046b9eea0ed22d9f14e836351622b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->